### PR TITLE
Update github actions to move from old node version

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -19,17 +19,17 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Azure Login
-        uses: Azure/login@v1
+        uses: Azure/login@v2
         with:
           client-id: f96c150d-cacf-4257-9cc9-54b2c68ec4ce
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
           subscription-id: 87897772-fb27-495f-ae40-486a2df57baa
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
This should remove these warnings:

"Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: Azure/login@v1, actions/checkout@v3, actions/setup-python@v3."