### PR TITLE
Log to stdout. Minimal logging for create case and workflow job, ordinary logging in forward job.

### DIFF
--- a/src/fmu/sumo/uploader/_fileondisk.py
+++ b/src/fmu/sumo/uploader/_fileondisk.py
@@ -15,11 +15,12 @@ import warnings
 import yaml
 
 from fmu.sumo.uploader._sumofile import SumoFile
+from fmu.sumo.uploader._logger import get_uploader_logger
+
 
 # pylint: disable=C0103 # allow non-snake case variable names
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.CRITICAL)
+logger = get_uploader_logger()
 
 
 def path_to_yaml_path(path):
@@ -54,15 +55,14 @@ def file_to_byte_string(path):
 
 
 class FileOnDisk(SumoFile):
-    def __init__(self, path: str, metadata_path=None, verbosity="INFO"):
+    def __init__(self, path: str, metadata_path=None, verbosity="WARNING"):
         """
         path (str): Path to file
         metadata_path (str): Path to metadata file. If not provided,
                              path will be derived from file path.
         """
 
-        self.verbosity = verbosity
-        logger.setLevel(level=self.verbosity)
+        logger.setLevel(level=verbosity)
 
         self.metadata_path = (
             metadata_path if metadata_path else path_to_yaml_path(path)

--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -11,11 +11,12 @@ import hashlib
 import base64
 
 from fmu.sumo.uploader._sumofile import SumoFile
+from fmu.sumo.uploader._logger import get_uploader_logger
+
 
 # pylint: disable=C0103 # allow non-snake case variable names
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.CRITICAL)
+logger = get_uploader_logger()
 
 class FileOnJob(SumoFile):
     def __init__(self, byte_string: str, metadata):

--- a/src/fmu/sumo/uploader/_logger.py
+++ b/src/fmu/sumo/uploader/_logger.py
@@ -1,0 +1,36 @@
+import logging
+import sys
+import os
+import time
+
+# def getLogger(module_name="subscript"):
+def get_uploader_logger(log_to_file=True):
+    # pylint: disable=invalid-name
+    """Provides a unified logger for fmu-sumo-uploader.
+
+    Code is copied from 
+    https://github.com/equinor/subscript/blob/main/src/subscript/__init__.py
+
+    Logging output is split by logging levels (split between WARNING and ERROR)
+    to stdout and stderr, each log occurs in only one of the streams. 
+
+    Returns:
+        A logger object
+    """
+    logger = logging.getLogger("fmu.sumo.uploader") 
+    logger.propagate = False # Avoids duplicate logging
+
+    if not len(logger.handlers):
+        formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+        
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.addFilter(lambda record: record.levelno < logging.ERROR)
+        stdout_handler.setFormatter(formatter)
+        logger.addHandler(stdout_handler)
+
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.addFilter(lambda record: record.levelno >= logging.ERROR)
+        stderr_handler.setFormatter(formatter)
+        logger.addHandler(stderr_handler)
+
+    return logger

--- a/src/fmu/sumo/uploader/_logger.py
+++ b/src/fmu/sumo/uploader/_logger.py
@@ -4,7 +4,7 @@ import os
 import time
 
 # def getLogger(module_name="subscript"):
-def get_uploader_logger(log_to_file=True):
+def get_uploader_logger():
     # pylint: disable=invalid-name
     """Provides a unified logger for fmu-sumo-uploader.
 

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -13,16 +13,17 @@ import httpx
 
 
 from fmu.sumo.uploader._upload_files import upload_files
+from fmu.sumo.uploader._logger import get_uploader_logger
+
 
 
 # pylint: disable=C0103 # allow non-snake case variable names
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.CRITICAL)
+logger = get_uploader_logger()
 
 
 class SumoCase:
-    def __init__(self, case_metadata: str, sumo_connection, verbosity):
+    def __init__(self, case_metadata: str, sumo_connection, verbosity="WARNING"):
         logger.setLevel(verbosity)
         self.sumo_connection = sumo_connection
         self.case_metadata = _sanitize_datetimes(case_metadata)

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -12,11 +12,12 @@ import subprocess
 import logging
 import warnings
 import httpx
+from fmu.sumo.uploader._logger import get_uploader_logger
+
 
 # pylint: disable=C0103 # allow non-snake case variable names
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
+logger = get_uploader_logger()
 
 
 def _get_segyimport_cmdstr(blob_url, object_id, file_path, sample_unit):

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -16,10 +16,11 @@ from fmu.sumo.uploader._sumocase import SumoCase
 from fmu.sumo.uploader._fileondisk import FileOnDisk
 from fmu.dataio import ExportData
 from fmu.dataio._utils import read_parameters_txt
+from fmu.sumo.uploader._logger import get_uploader_logger
 
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.CRITICAL)
+
+logger = get_uploader_logger()
 
 # pylint: disable=C0103 # allow non-snake case variable names
 
@@ -64,7 +65,7 @@ class CaseOnDisk(SumoCase):
     """
 
     def __init__(
-        self, case_metadata_path: str, sumo_connection, verbosity=logging.INFO
+        self, case_metadata_path: str, sumo_connection, verbosity=logging.WARNING
     ):
         """Initialize CaseOnDisk.
 

--- a/src/fmu/sumo/uploader/caseonjob.py
+++ b/src/fmu/sumo/uploader/caseonjob.py
@@ -5,9 +5,10 @@ import warnings
 
 from fmu.sumo.uploader._sumocase import SumoCase
 from fmu.sumo.uploader._fileonjob import FileOnJob
+from fmu.sumo.uploader._logger import get_uploader_logger
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.CRITICAL)
+
+logger = get_uploader_logger()
 
 # pylint: disable=C0103 # allow non-snake case variable names
 


### PR DESCRIPTION
3 ways of triggering uploads are tested successfully in RGS:

1: create case metadata: shall be 'quiet'    (fmu-dataio calls CaseOnDisk)
2: worflow job: shall be 'quiet'                   (sumo_upload.py:SumoUpload.run -> sumo_upload_main -> CaseOnDisk)
3: forward jobs: shall _not_ be 'quiet'        (sumo_upload.py:main -> sumo_upload_main -> CaseOnDisk)