### PR TITLE
Update nightly tests to handle updated komodo-releases

### DIFF
--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -1,9 +1,18 @@
-""" Verifies SUMO uploads that has been run by Github Actions in the komodo-releases repo. 
+""" Verifies SUMO uploads that has been run by Github Actions in the 
+    komodo-releases repo. See 
     https://github.com/equinor/komodo-releases/blob/main/.github/workflows/run_drogon.yml
-"""
+
+    Verify that the expected number of objects of each expected type have been
+    uploaded. Note that komodo-releases repo usually runs multiple times every
+    day, and that many failed runs is to be expected, i.e. do not expect 
+    every upload to be perfect. 
+    Tests of aggregations are not in scope here, see the Sumo aggregation repo
+    for those tests. 
+    """
+
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import pytest
 from pathlib import Path
 import logging
@@ -45,143 +54,297 @@ def _get_creation_date(metadata):
     """Returns the date this case was created, based on the case metadata"""
     for item in metadata["tracklog"]:
         if item["event"] == "created":
-            return item["datetime"]
+            timestr = item["datetime"]
+            if timestr.endswith("Z"):
+                timestr = timestr.replace("Z", "+00:00")
+            if "+" not in timestr:
+                timestr = timestr + "+00:00"
+            dt = datetime.strptime(timestr, "%Y-%m-%dT%H:%M:%S.%f%z")
+            return dt
 
 
-def _get_newest_case(explorer):
-    """Returns latest case that was uploaded by f_scout_ci"""
+def _get_suitable_cases(explorer):
+    """Returns list of suitable cases that was uploaded by f_scout_ci
+    recently"""
     cases = explorer.cases
     cases.users
     cases = cases.filter(user="f_scout_ci")
     assert len(cases) > 0
-    newest_date = "2000-01-01T00:00:00.000Z"
-    newest_case = cases[0]
+    selected = []
+    an_hour_ago = datetime.now(timezone.utc) + timedelta(hours=-1)
+    a_day_ago = datetime.now(timezone.utc) + timedelta(hours=-24)
     for case in cases:
-        case_created_at = _get_creation_date(case.metadata)
-        if case_created_at > newest_date:
-            newest_date = case_created_at
-            newest_case = case
+        case_created = _get_creation_date(case.metadata)
+        if case_created > an_hour_ago:
+            # Could still be uploading, skip
+            print("Too new: ", case_created, case.uuid)
+            continue
+        if case_created < a_day_ago:
+            # Too old for this nightly test
+            print("Too old:", case_created, case.uuid)
+            continue
+        if len(case.get_realizations()) < 1:
+            # Skip cases wo realizations, typically these are
+            # failed runs in komodo-releases / ert
+            print("Too few realizations:", case_created, case.uuid)
+            continue
+        selected.append(case)
 
-    print("Newest case: ", newest_case.uuid, " ", newest_case.name)
-    return newest_case
+    print("Number of cases selected for further testing:", len(selected))
+    for case in selected:
+        print("   ", _get_creation_date(case.metadata), case.uuid)
+
+    assert len(selected) > 0, "Could not find any suitable case for testing"
+    return selected
 
 
 def test_case_surfaces(explorer: Explorer):
-    """Test surfaces from the latest case uploaded from komodo-releases"""
-    case = _get_newest_case(explorer)
-    assert case
-    iter_count = 0
-    real_count = 0
-    for surf in case.surfaces:
-        assert surf.uuid
-        assert surf.name
-        assert surf.tagname
-        if surf.iteration is not None:
-            iter_count += 1
-        if surf.realization is not None:
-            real_count += 1
-    assert iter_count > 53
-    assert real_count > 53
-    # No need to test every blob element every time
+    """Test surfaces from cases uploaded from komodo-releases"""
+    cases = _get_suitable_cases(explorer)
+    perfect_cases = 0
+    for case in cases:
+        realizations = len(case.get_realizations())
+        iter_count = 0
+        real_count = 0
+        preproc_count = 0
+        for surf in case.surfaces:
+            assert surf.uuid
+            assert surf.name
+            assert surf.tagname
+            if surf.metadata.get("fmu").get("aggregation") is not None:
+                continue
+            if surf.iteration is not None:
+                iter_count += 1
+            if surf.realization is not None:
+                real_count += 1
+            if surf.iteration is None and surf.realization is None:
+                preproc_count += 1
+        if (
+            iter_count >= 54 * realizations
+            and real_count >= 54 * realizations
+            and preproc_count >= 33
+        ):
+            print(
+                "'Perfect' surface case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                preproc_count,
+                realizations,
+            )
+            perfect_cases += 1
+        else:
+            print(
+                "'NOT perfect' surface case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                preproc_count,
+                realizations,
+            )
+
+    # Will not test every blob element,
+    # just test that a random blob can be read
     seed()
     random_index = randint(0, len(case.surfaces) - 1)
     reg = case.surfaces[random_index].to_regular_surface()
     mean = reg.values.mean()
-    assert mean
+    assert mean, "Failed to read content of a blob"
+
+    print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
+    # There could be many failed runs from komodo-release repo,
+    # so lets be happy if we find 1 or more 'perfect' cases.
+    assert perfect_cases > 0, "None of the cases satisfy the surface test"
 
 
 def test_case_tables(explorer: Explorer):
-    """Test tables from the latest case uploaded from komodo-releases"""
-    case = _get_newest_case(explorer)
-    assert case
-    iter_count = 0
-    real_count = 0
-    tagname_count = 0
-    # SIM2SUMO uploads:
-    drogon_rft = False
-    drogon_satfunc = False
-    drogon_summary = False
-    for tbl in case.tables:
-        assert tbl.uuid
-        assert tbl.name
-        if tbl.iteration is not None:
-            iter_count += 1
-        if tbl.realization is not None:
-            real_count += 1
-        if tbl.tagname is not None:
-            tagname_count += 1
-        if tbl.name == "DROGON" and tbl.tagname == "rft":
-            drogon_rft = True
-        if tbl.name == "DROGON" and tbl.tagname == "satfunc":
-            drogon_satfunc = True
-        if tbl.name == "DROGON" and tbl.tagname == "summary":
-            drogon_summary = True
-    assert iter_count > 6
-    assert real_count > 6
-    assert tagname_count > 6
-    assert drogon_rft
-    assert drogon_satfunc
-    assert drogon_summary
-    # No need to test every blob element every time
+    """Test tables from cases uploaded from komodo-releases"""
+    cases = _get_suitable_cases(explorer)
+    perfect_cases = 0
+    for case in cases:
+        realizations = len(case.get_realizations())
+        iter_count = 0
+        real_count = 0
+        tagname_count = 0
+        # SIM2SUMO uploads:
+        drogon_rft_count = 0
+        drogon_satfunc_count = 0
+        drogon_summary_count = 0
+
+        for tbl in case.tables:
+            assert tbl.uuid
+            assert tbl.name
+            if tbl.metadata.get("fmu").get("aggregation") is not None:
+                continue
+            if tbl.iteration is not None:
+                iter_count += 1
+            if tbl.realization is not None:
+                real_count += 1
+            if tbl.tagname is not None:
+                tagname_count += 1
+            if tbl.name == "DROGON" and tbl.tagname == "rft":
+                drogon_rft_count += 1
+            if tbl.name == "DROGON" and tbl.tagname == "satfunc":
+                drogon_satfunc_count += 1
+            if tbl.name == "DROGON" and tbl.tagname == "summary":
+                drogon_summary_count += 1
+        if (
+            iter_count >= 7 * realizations
+            and real_count >= 7 * realizations
+            and tagname_count >= 7 * realizations
+            and drogon_rft_count >= 1 * realizations
+            and drogon_satfunc_count >= 1 * realizations
+            and drogon_summary_count >= 1 * realizations
+        ):
+            print(
+                "'Perfect' table case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                tagname_count,
+                realizations,
+            )
+            perfect_cases += 1
+        else:
+            print(
+                "'NOT perfect' table case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                tagname_count,
+                realizations,
+            )
+
+    # Will not test every blob element,
+    # just test that a random blob can be read
     seed()
     random_index = randint(0, len(case.tables) - 1)
     arrow = case.tables[random_index].to_arrow()
-    arrow.validate() 
+    arrow.validate()
+
+    print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
+    # There could be many failed runs from komodo-release repo,
+    # so lets be happy if we find 1 or more 'perfect' cases.
+    assert perfect_cases > 0, "None of the cases satisfy the table test"
 
 
 def test_case_polygons(explorer: Explorer):
-    """Test polygons from the latest case uploaded from komodo-releases"""
-    case = _get_newest_case(explorer)
-    assert case
-    iter_count = 0
-    real_count = 0
-    tagname_count = 0
-    for poly in case.polygons:
-        assert poly.uuid
-        assert poly.name
-        if poly.iteration is not None:
-            iter_count += 1
-        if poly.realization is not None:
-            real_count += 1
-        if poly.tagname is not None:
-            tagname_count += 1
-    assert iter_count > 5
-    assert real_count > 5
-    assert tagname_count > 5
-    # No need to test every blob element every time
+    """Test polygons from cases uploaded from komodo-releases"""
+    cases = _get_suitable_cases(explorer)
+    perfect_cases = 0
+    for case in cases:
+        realizations = len(case.get_realizations())
+        iter_count = 0
+        real_count = 0
+        tagname_count = 0
+        for poly in case.polygons:
+            assert poly.uuid
+            assert poly.name
+            if poly.metadata.get("fmu").get("aggregation") is not None:
+                continue
+            if poly.iteration is not None:
+                iter_count += 1
+            if poly.realization is not None:
+                real_count += 1
+            if poly.tagname is not None:
+                tagname_count += 1
+        if (
+            iter_count >= 6 * realizations
+            and real_count >= 6 * realizations
+            and tagname_count >= 6 * realizations
+        ):
+            print(
+                "'Perfect' polygon case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                tagname_count,
+                realizations,
+            )
+            perfect_cases += 1
+        else:
+            print(
+                "'NOT perfect' polygon case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                tagname_count,
+                realizations,
+            )
+
+    # Will not test every blob element,
+    # just test that a random blob can be read
     seed()
     random_index = randint(0, len(case.polygons) - 1)
     case.polygons[random_index].to_pandas()
-    
+
+    print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
+    # There could be many failed runs from komodo-release repo,
+    # so lets be happy if we find 1 or more 'perfect' cases.
+    assert perfect_cases > 0, "None of the cases satisfy the polygon test"
+
 
 def test_case_dictionaries(explorer: Explorer):
-    """Test dictionaries from the latest case uploaded from komodo-releases"""
-    case = _get_newest_case(explorer)
-    assert case
-    iter_count = 0
-    real_count = 0
-    tagname_count = 0
-    name_parameter_found = False
-    for dct in case.dictionaries:
-        assert dct.uuid
-        assert dct.name
-        if dct.iteration is not None:
-            iter_count += 1
-        if dct.realization is not None:
-            real_count += 1
-        if dct.tagname is not None:
-            tagname_count += 1
-        if dct.name == "parameters":
-            name_parameter_found = True
-    assert iter_count > 0
-    assert real_count > 0
-    assert tagname_count >= 0
-    assert name_parameter_found
-    # No need to test every blob element every time
+    """Test dictionaries from cases uploaded from komodo-releases"""
+    cases = _get_suitable_cases(explorer)
+    perfect_cases = 0
+    for case in cases:
+        realizations = len(case.get_realizations())
+        iter_count = 0
+        real_count = 0
+        tagname_count = 0
+        name_parameter_found = False
+        for dct in case.dictionaries:
+            assert dct.uuid
+            assert dct.name
+            if dct.metadata.get("fmu").get("aggregation") is not None:
+                continue
+            if dct.iteration is not None:
+                iter_count += 1
+            if dct.realization is not None:
+                real_count += 1
+            if dct.tagname is not None:
+                tagname_count += 1
+            if dct.name == "parameters":
+                name_parameter_found = True
+        if (
+            iter_count >= 1 * realizations
+            and real_count >= 1 * realizations
+            and tagname_count >= 1 * realizations
+            and name_parameter_found
+        ):
+            print(
+                "'Perfect' dictionary case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                tagname_count,
+                name_parameter_found,
+                realizations,
+            )
+            perfect_cases += 1
+        else:
+            print(
+                "'NOT perfect' dicationary case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                tagname_count,
+                name_parameter_found,
+                realizations,
+            )
+
+    # Will not test every blob element,
+    # just test that a random blob can be read
     seed()
     random_index = randint(0, len(case.dictionaries) - 1)
     obj = case.dictionaries[random_index]
     obj._blob
+
+    print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
+    # There could be many failed runs from komodo-release repo,
+    # so lets be happy if we find 1 or more 'perfect' cases.
+    assert perfect_cases > 0, "None of the cases satisfy the dictionary test"
 
 
 @pytest.mark.skipif(
@@ -189,24 +352,43 @@ def test_case_dictionaries(explorer: Explorer):
     reason="do not run OpenVDS on mac os",
 )
 def test_case_seismic(explorer: Explorer):
-    """Test seismic cubes in the latest case uploaded from komodo-releases"""
-    case = _get_newest_case(explorer)
-    assert case
-    assert len(case.cubes) > 9
-    iter_count = 0
-    real_count = 0
-    for cube in case.cubes:
-        assert cube.uuid
-        assert cube.name
-        assert cube.tagname
-        if cube.iteration is not None:
-            iter_count += 1
-        if cube.realization is not None:
-            real_count += 1
-    assert iter_count > 9
-    assert real_count > 9
+    """Test seismic cubes in cases uploaded from komodo-releases"""
+    cases = _get_suitable_cases(explorer)
+    perfect_cases = 0
+    for case in cases:
+        realizations = len(case.get_realizations())
+        iter_count = 0
+        real_count = 0
+        for cube in case.cubes:
+            assert cube.uuid
+            assert cube.name
+            assert cube.tagname
+            if cube.metadata.get("fmu").get("aggregation") is not None:
+                continue
+            if cube.iteration is not None:
+                iter_count += 1
+            if cube.realization is not None:
+                real_count += 1
+        if iter_count >= 10 * realizations and real_count >= 10 * realizations:
+            print(
+                "'Perfect' seismic case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                realizations,
+            )
+            perfect_cases += 1
+        else:
+            print(
+                "'NOT perfect' seismic case:",
+                case.uuid,
+                iter_count,
+                real_count,
+                realizations,
+            )
 
-    # No need to test every blob element every time
+    # Will not test every blob element,
+    # just test that a random blob can be read
     seed()
     random_index = randint(0, len(case.cubes) - 1)
     cube = case.cubes[random_index]
@@ -215,27 +397,7 @@ def test_case_seismic(explorer: Explorer):
     channel_count = layout.getChannelCount()
     assert channel_count > 0
 
-
-def test_case(explorer: Explorer):
-    """Test the latest case uploaded from komodo-releases by f_scout_ci"""
-    case = _get_newest_case(explorer)
-    assert case
-    number_of_children = (
-        len(case.cubes)
-        + len(case.polygons)
-        + len(case.surfaces)
-        + len(case.dictionaries)
-        + len(case.tables)
-    )
-    assert number_of_children > 110
-    assert len(case.surfaces) > 86
-    assert len(case.cubes) > 9
-    assert len(case.tables) > 6
-    assert len(case.polygons) > 5
-    assert len(case.dictionaries) > 0
-
-    case_timestamp = _get_creation_date(case.metadata)
-    yesterday = datetime.now() - timedelta(days=1)
-    print("Timestamp of latest case: ", case_timestamp)
-    # Assuming that komodo-releases repo Github Actions runs at least every 24 hours:
-    assert case_timestamp > yesterday.strftime("%Y-%m-%dT%H:%M"), f"The newest case is too old: {case_timestamp}: check komodo-releases repo Github Actions runs"
+    print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
+    # There could be many failed runs from komodo-release repo,
+    # so lets be happy if we find 1 or more 'perfect' cases.
+    assert perfect_cases > 0, "None of the cases satisfy the seismic test"


### PR DESCRIPTION
Komodo-releases nightly github actions now uploads some cases with 1 realization and some cases with 2 realizations. These tests handle both versions. 
Also, pass the test if we can find a single case that satisfies, i.e allow that many runs fail partially on the komodo-releases side. 
Also, do not use recently created cases for testing, as they can still be uploading. 

Note that the tests are similar, but the similarity is expected to dwindle as the tests are improved in the future. 