### PR TITLE
Fix metadata checksum_md5 for disk-less uploads

### DIFF
--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -39,8 +39,7 @@ class FileOnJob(SumoFile):
         self.metadata["_sumo"]["blob_md5"] = base64.b64encode(
             digester.digest()
         ).decode("utf-8")
+        self.metadata["file"]["checksum_md5"] = digester.hexdigest()
 
-        # TODO hack
         self.metadata["file"]["absolute_path"] = ""
-        self.metadata["file"]["checksum_md5"] = self.metadata["_sumo"]["blob_md5"]
 


### PR DESCRIPTION
The old code gives wrong file.checksum_md5 for disk-less uploads. 
Now calculating this same way as fmu-dataio. 