### PR TITLE
Elide exception tracebacks from log.

### DIFF
--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -145,6 +145,7 @@ class SumoFile:
             )
             pass
         except (httpx.TimeoutException, httpx.ConnectError) as err:
+            err = err.with_traceback(None)
             logger.warning(
                 f"Metadata upload timeout/connection exception {err} {type(err)}"
             )
@@ -157,6 +158,7 @@ class SumoFile:
             )
             pass
         except httpx.HTTPStatusError as err:
+            err = err.with_traceback(None)
             error_string = (
                 str(err.response.status_code)
                 + err.response.reason_phrase
@@ -176,6 +178,7 @@ class SumoFile:
             )
             pass
         except Exception as err:
+            err = err.with_traceback(None)
             logger.warning(f"Metadata upload exception {err} {type(err)}")
             result.update(
                 {
@@ -253,6 +256,7 @@ class SumoFile:
                         pass
                     pass
                 except Exception as err:
+                    err = err.with_traceback(None)
                     logger.warning(
                         f"Seismic upload exception {err} {type(err)}"
                     )
@@ -280,6 +284,7 @@ class SumoFile:
                 )
                 pass
             except (httpx.TimeoutException, httpx.ConnectError) as err:
+                err = err.with_traceback(None)
                 logger.warning(
                     f"Blob upload failed on timeout/connect {err} {type(err)}"
                 )
@@ -294,6 +299,7 @@ class SumoFile:
                 )
                 pass
             except httpx.HTTPStatusError as err:
+                err = err.with_traceback(None)
                 logger.warning(
                     f"Blob upload failed on status {err} {type(err)} {err.response.text}"
                 )
@@ -308,6 +314,7 @@ class SumoFile:
                 )
                 pass
             except Exception as err:
+                err = err.with_traceback(None)
                 logger.warning(
                     f"Blob upload failed on exception {err} {type(err)}"
                 )
@@ -363,6 +370,7 @@ class SumoFile:
                             metadatafile_path,
                         )
                 except Exception as err:
+                    err = err.with_traceback(None)
                     err_msg = (
                         f"Error deleting file after upload: {err} {type(err)}"
                     )

--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -148,7 +148,8 @@ def _upload_files(
                 )
             except Exception as e:
                 logger.error(
-                    "Failed to upload realization and iteration objects: %s", e
+                    "Failed to upload realization and iteration objects: %s",
+                    e.with_traceback(None)
                 )
 
             paramfile = create_parameter_file(

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -154,6 +154,7 @@ def sumo_upload_main(
         e.upload(threads=threads)
         logger.info("Upload done")
     except Exception as err:
+        err = err.with_traceback(None)
         logger.warning(f"Problem related to Sumo upload: {err} {type(err)}")
         _sumo_logger = sumo_connection.api.getLogger("fmu-sumo-uploader")
         _sumo_logger.propagate = False


### PR DESCRIPTION
Just in case we have tracebacks witgh large data structures (which we sometimes do have).