### PR TITLE
Don't want to copy _sumo.blob_size etc...

### DIFF
--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -104,6 +104,7 @@ def maybe_upload_realization_and_iteration(sumoclient, base_metadata):
         del realization_metadata["data"]
         del realization_metadata["file"]
         del realization_metadata["display"]
+        realization_metadata["_sumo"] = {}
         realization_metadata["class"] = "realization"
         realization_metadata["fmu"]["context"]["stage"] = "realization"
 


### PR DESCRIPTION
 ... from base metadata when uploading iteration and realization objects.