### PR TITLE
Do not even try to upload sesimic data that does not have data.vertical_domain

### DIFF
--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -130,6 +130,15 @@ class SumoFile:
             and self.metadata.get("data").get("format") in ["openvds", "segy"]
         ):
             self.metadata["data"]["format"] = "openvds"
+            if "vertical_domain" not in self.metadata["data"]:
+                result.update(
+                    {
+                        "status": "rejected",
+                        "metadata_upload_response_status_code": 500,
+                        "metadata_upload_response_text": "File upload cannot be attempted; this is a seismic data object but it does not have a value for data.vertical_domain."
+                        }
+                    )
+                return result
 
         try:
             response = self._upload_metadata(


### PR DESCRIPTION
Seismic data (seismic cubes) are converted into OpenVDS format and uploaded into a dedicated storage account. The conversion process needs information about the data; specifically, the value of `data.vertical_domain` should be either `depth` or `time`, and the `sample_unit` parameter of the conversion command is then accordingly set to either `m` (metres) or `ms` (milliseconds).

If `data.vertical_domain` is missing (or set to something other than `depth` or `time`) we cannot perform the conversion into OpenVDS, and we do not try to upload the object.