### PR TITLE
chore: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
     permissions:
       contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,15 @@ line-length = 79
 
 [project]
 name = "fmu-sumo-uploader"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    "sumo-wrapper-python>=1.0.3",
-    "azure.storage.blob",
-    "fmu-dataio",
-    "httpx>=0.24.1",
-    "OpenVDS; sys_platform != 'darwin' and python_version < '3.12'",
-    "ert; sys_platform != 'win32'",
+  "sumo-wrapper-python>=1.0.3",
+  "azure.storage.blob",
+  "fmu-dataio",
+  "httpx>=0.24.1",
+  "OpenVDS; sys_platform != 'darwin' and python_version < '3.12'",
+  "ert; sys_platform != 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Resolves #107 