### PR TITLE
fix: Use correct name when getting sumoclient logger

### DIFF
--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -90,7 +90,7 @@ class CaseOnDisk(SumoCase):
             parameters_path,
         )
 
-        self._sumo_logger = sumoclient.getLogger("fmu-sumo-uploader")
+        self._sumo_logger = sumoclient.get_logger("fmu-sumo-uploader")
         self._sumo_logger.setLevel(logging.INFO)
         # Avoid that logging to sumo-server also is visible in local logging:
         self._sumo_logger.propagate = False

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -157,7 +157,7 @@ def sumo_upload_main(
     except Exception as err:
         err = err.with_traceback(None)
         logger.warning(f"Problem related to Sumo upload: {err} {type(err)}")
-        _sumo_logger = sumoclient.getLogger("fmu-sumo-uploader")
+        _sumo_logger = sumoclient.get_logger("fmu-sumo-uploader")
         _sumo_logger.propagate = False
         _sumo_logger.warning(
             "Problem related to Sumo upload for case: %s; %s %s",


### PR DESCRIPTION
Solves Komodo bleeding build fail: https://equinor.slack.com/archives/CKC3H3W74/p1733985023644679?thread_ts=1733965770.042389&cid=CKC3H3W74