### PR TITLE
fix: Do not set absolute_path to empty in FileOnJob init

### DIFF
--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -40,4 +40,5 @@ class FileOnJob(SumoFile):
         ).decode("utf-8")
         self.metadata["file"]["checksum_md5"] = digester.hexdigest()
 
-        # self.metadata["file"]["absolute_path"] = ""
+        if "absolute_path" not in self.metadata["file"]:
+            self.metadata["file"]["absolute_path"] = ""

--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -40,4 +40,4 @@ class FileOnJob(SumoFile):
         ).decode("utf-8")
         self.metadata["file"]["checksum_md5"] = digester.hexdigest()
 
-        self.metadata["file"]["absolute_path"] = ""
+        # self.metadata["file"]["absolute_path"] = ""

--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -39,6 +39,3 @@ class FileOnJob(SumoFile):
             digester.digest()
         ).decode("utf-8")
         self.metadata["file"]["checksum_md5"] = digester.hexdigest()
-
-        if "absolute_path" not in self.metadata["file"]:
-            self.metadata["file"]["absolute_path"] = ""


### PR DESCRIPTION
Related to https://github.com/equinor/fmu-sumo-sim2sumo/pull/127
`FileOnJob` overwrites `absolute_path` if it is already set.

Not quite sure why we do this, might be that something down the line expects the key to exist.
Everything seems to run fine without setting `absolute_path` so removing it.
