### PR TITLE
fix: nightly tests failing

### DIFF
--- a/.github/workflows/run_tests_on_uploads_from_komodo.yaml
+++ b/.github/workflows/run_tests_on_uploads_from_komodo.yaml
@@ -1,6 +1,8 @@
 name: Verify case previously uploaded from komodo-releases repo
 
 on:
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "3 3 * * *"
 

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -104,10 +104,12 @@ def test_case_consistency(explorer: Explorer):
     cases = _get_suitable_cases(explorer)
     non_consistent_cases = 0
     for case in cases:
-        mismatches_request = explorer._sumo.get(f"/admin/mismatches?case={case.uuid}")
+        mismatches_request = explorer._sumo.get(
+            f"/admin/mismatches?case={case.uuid}"
+        )
         mismatches_res_location = mismatches_request.headers.get("location")
         res_url = mismatches_res_location.removeprefix(explorer._sumo.base_url)
-        time.sleep(3) # Give time for result to be ready
+        time.sleep(3)  # Give time for result to be ready
         res = explorer._sumo.get(res_url)
         metadata_wo_blobs = len(res.json().get("metadata_without_blobs"))
         blobs_wo_metadata = len(res.json().get("blobs_without_metadata"))
@@ -169,7 +171,9 @@ def test_case_surfaces(explorer: Explorer):
     seed()
     random_index = randint(0, len(case.surfaces) - 1)
     reg = case.surfaces[random_index].to_regular_surface()
-    assert type(reg) == xtgeo.RegularSurface, "Failed to read content of a blob"
+    assert type(reg) is xtgeo.RegularSurface, (
+        "Failed to read content of a blob"
+    )
 
     print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
     # There could be many failed runs from komodo-release repo,

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -13,6 +13,7 @@ for those tests.
 import logging
 import os
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from random import randint, seed
@@ -103,7 +104,11 @@ def test_case_consistency(explorer: Explorer):
     cases = _get_suitable_cases(explorer)
     non_consistent_cases = 0
     for case in cases:
-        res = explorer._sumo.get(f"/admin/mismatches?case={case.uuid}")
+        mismatches_request = explorer._sumo.get(f"/admin/mismatches?case={case.uuid}")
+        mismatches_res_location = mismatches_request.headers.get("location")
+        res_url = mismatches_res_location.removeprefix(explorer._sumo.base_url)
+        time.sleep(3) # Give time for result to be ready
+        res = explorer._sumo.get(res_url)
         metadata_wo_blobs = len(res.json().get("metadata_without_blobs"))
         blobs_wo_metadata = len(res.json().get("blobs_without_metadata"))
         if metadata_wo_blobs > 0 or blobs_wo_metadata > 0:

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -102,7 +102,7 @@ def test_case_consistency(explorer: Explorer):
     cases = _get_suitable_cases(explorer)
     non_consistent_cases = 0
     for case in cases:
-        res = explorer._sumo.get(f"/admin/consistency-check?case={case.uuid}")
+        res = explorer._sumo.get(f"/admin/mismatches?case={case.uuid}")
         metadata_wo_blobs = len(res.json().get("metadata_without_blobs"))
         blobs_wo_metadata = len(res.json().get("blobs_without_metadata"))
         if metadata_wo_blobs > 0 or blobs_wo_metadata > 0:

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -13,7 +13,6 @@ for those tests.
 import logging
 import os
 import sys
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from random import randint, seed
@@ -104,13 +103,10 @@ def test_case_consistency(explorer: Explorer):
     cases = _get_suitable_cases(explorer)
     non_consistent_cases = 0
     for case in cases:
-        mismatches_request = explorer._sumo.get(
+        mismatches_response = explorer._sumo.get(
             f"/admin/mismatches?case={case.uuid}"
         )
-        mismatches_res_location = mismatches_request.headers.get("location")
-        res_url = mismatches_res_location.removeprefix(explorer._sumo.base_url)
-        time.sleep(3)  # Give time for result to be ready
-        res = explorer._sumo.get(res_url)
+        res = explorer._sumo.poll(mismatches_response)
         metadata_wo_blobs = len(res.json().get("metadata_without_blobs"))
         blobs_wo_metadata = len(res.json().get("blobs_without_metadata"))
         if metadata_wo_blobs > 0 or blobs_wo_metadata > 0:

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -28,7 +28,6 @@ if not sys.platform.startswith("darwin"):
 TEST_DIR = Path(__file__).parent / "../"
 os.chdir(TEST_DIR)
 
-ENV = "dev"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(level="DEBUG")
@@ -68,7 +67,6 @@ def _get_suitable_cases(explorer):
     """Returns list of suitable cases that was uploaded by f_scout_ci
     recently"""
     cases = explorer.cases
-    cases.users
     cases = cases.filter(user="f_scout_ci")
     assert len(cases) > 0
     selected = []

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from random import randint, seed
 
 import pytest
+import xtgeo
 
 from fmu.sumo.explorer import Explorer
 
@@ -163,8 +164,7 @@ def test_case_surfaces(explorer: Explorer):
     seed()
     random_index = randint(0, len(case.surfaces) - 1)
     reg = case.surfaces[random_index].to_regular_surface()
-    mean = reg.values.mean()
-    assert mean, "Failed to read content of a blob"
+    assert type(reg) == xtgeo.RegularSurface, "Failed to read content of a blob"
 
     print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
     # There could be many failed runs from komodo-release repo,


### PR DESCRIPTION
Closes #116 

* Some surfaces apparently can have no actual values which makes testing `values.mean()` not work. Changed to assert that the blob is `xtgeo.RegularSurface`
* `consistency-check` was renamed to `mismatches` and now returns "location" where the response can be found. Test now gets the response from the specified location.
* Running `test_uploads_from_komodo.py` on PRs in addition to the schedule.