### PR TITLE
fix: always check if slack notification should be sent

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/run_tests_on_uploads_from_komodo.yaml
   notify_on_failure:
     needs: [run_uploader_tests, run_tests_on_uploads_from_komodo]
-    if: ${{ github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Notify on Slack


### PR DESCRIPTION
Add `always()` to notification step to always evaluate if notification should be sent.