### PR TITLE
chore: set DEV_SCHEMA env var in conftest

### DIFF
--- a/.github/workflows/run_uploader_tests.yaml
+++ b/.github/workflows/run_uploader_tests.yaml
@@ -42,7 +42,6 @@ jobs:
           az account list
           pip list | grep sumo || echo 'sumo not installed'
           pip list | grep openvds || echo 'openvds not installed'
-          export DEV_SCHEMA=1 # use fmu-dataio dev schema
           python -c  'import sys; print(sys.platform)'
           python -c 'import os; import sys; print(os.path.dirname(sys.executable))'
           access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,5 @@ def pytest_generate_tests(metafunc):
 
     if "token" in metafunc.fixturenames:
         metafunc.parametrize("token", [token])
+
+    os.environ["DEV_SCHEMA"] = "1"  # use fmu-dataio dev schema


### PR DESCRIPTION
Set `DEV_SCHEMA=1` as part of the test run instead of the workflow.

if not, tests ran outside of the workflow (e.g. locally) will not use the dev schema and might fail because it's trying to use a non-existent schema.