### PR TITLE
fix: build readthedocs using python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
     os: ubuntu-22.04
     tools:
-        python: "3.10"
+        python: "3.12"
 
 python:
     install:


### PR DESCRIPTION
Build fails since Python 3.10 is no longer supported.
Update to build using 3.12.