### PR TITLE
feat: use manifest instead of searchpath

### DIFF
--- a/src/fmu/sumo/uploader/_fileondisk.py
+++ b/src/fmu/sumo/uploader/_fileondisk.py
@@ -51,7 +51,7 @@ class FileOnDisk(SumoFile):
         self.metadata_path = (
             metadata_path if metadata_path else _path_to_yaml_path(path)
         )
-        self.path = os.path.abspath(path)
+        self.path = path
         self.metadata = parse_yaml(self.metadata_path)
 
         self._size = os.path.getsize(self.path)

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -68,7 +68,7 @@ class SumoCase:
             err_msg = f"Invalid metadata: Could not get fmu.case.uuid from case metadata: {err} {type(err)}"
             warnings.warn(err_msg)
             return None
-    
+
     def _load_export_manifest(self):
         """Load export manifest from file."""
 
@@ -86,14 +86,15 @@ class SumoCase:
     def _load_sumo_uploads(self):
         """Load sumo uploads log from file."""
 
-        uploads_path = get_manifest_path(self.casepath).parent / ".sumo_uploads.json"
+        uploads_path = (
+            get_manifest_path(self.casepath).parent / ".sumo_uploads.json"
+        )
 
         if not os.path.exists(uploads_path):
             return []
 
         with open(uploads_path, "r", encoding="utf-8") as uploads_json:
             return json.load(uploads_json)
-    
 
     def upload(self, threads=4):
         """Trigger upload of files.
@@ -232,7 +233,9 @@ class SumoCase:
         """Update sumo uploads log."""
 
         manifest = self._load_export_manifest()
-        uploads_path = get_manifest_path(self.casepath).parent / ".sumo_uploads.json"
+        uploads_path = (
+            get_manifest_path(self.casepath).parent / ".sumo_uploads.json"
+        )
         sumo_uploads = self._load_sumo_uploads()
         new_entry = {
             "last_index_manifest": len(manifest) - 1,
@@ -243,7 +246,9 @@ class SumoCase:
         with open(uploads_path, "w") as file:
             json.dump(sumo_uploads, file, indent=4)
 
-        logger.info(f"Sumo log {uploads_path} updated with new entry: {new_entry}")
+        logger.info(
+            f"Sumo log {uploads_path} updated with new entry: {new_entry}"
+        )
 
 
 def _get_log_msg(sumo_parent_id, status):

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -24,12 +24,12 @@ class SumoCase:
     def __init__(
         self,
         case_metadata: str,
-        casepath,
         sumoclient,
         verbosity="WARNING",
         sumo_mode="copy",
         config_path="fmuconfig/output/global_variables.yml",
         parameters_path="parameters.txt",
+        casepath="path/to/casepath",
     ):
         logger.setLevel(verbosity)
         self.sumoclient = sumoclient

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -5,15 +5,15 @@ Base class for CaseOnJob and CaseOnDisk classes.
 """
 
 import datetime
+import json
+import os
 import statistics
 import time
 import warnings
-import json
-import os
 
+from fmu.dataio.manifest import get_manifest_path
 from fmu.sumo.uploader._logger import get_uploader_logger
 from fmu.sumo.uploader._upload_files import upload_files
-from fmu.dataio.manifest import get_manifest_path
 
 # pylint: disable=C0103 # allow non-snake case variable names
 

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -222,8 +222,14 @@ class CaseOnDisk(SumoCase):
         if next_index > len(manifest) - 1:
             files = []
         else:
-            logger.info(f"Upload will start from index {next_index} in manifest.")
-            files = [f["absolute_path"] for f in manifest[next_index:] if os.path.isfile(f["absolute_path"])]
+            logger.info(
+                f"Upload will start from index {next_index} in manifest."
+            )
+            files = [
+                f["absolute_path"]
+                for f in manifest[next_index:]
+                if os.path.isfile(f["absolute_path"])
+            ]
 
         if len(files) == 0:
             warnings.warn("No files found!")

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -1,6 +1,5 @@
 """Objectify an FMU case (results) as it appears on the disk."""
 
-import glob
 import logging
 import os
 import time
@@ -9,12 +8,10 @@ from pathlib import Path
 
 import httpx
 import yaml
-import json
 
 from fmu.sumo.uploader._fileondisk import FileOnDisk
 from fmu.sumo.uploader._logger import get_uploader_logger
 from fmu.sumo.uploader._sumocase import SumoCase
-from fmu.dataio.manifest import get_manifest_path
 
 logger = get_uploader_logger()
 
@@ -221,7 +218,7 @@ class CaseOnDisk(SumoCase):
         sumo_uploads = self._load_sumo_uploads()
         next_index = self._get_next_index(manifest, sumo_uploads)
 
-        logger.info(f"Finding files to upload.")
+        logger.info("Finding files to upload.")
         if next_index > len(manifest) - 1:
             files = []
         else:

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -38,7 +38,7 @@ class CaseOnDisk(SumoCase):
 
         >>> env = 'dev'
         >>> case_metadata_path = 'path/to/case_metadata.yaml'
-        >>> search_path = 'path/to/search_path/'
+        >>> case_path = 'path/to/case_path/'
 
         >>> sumoclient = sumo.wrapper.SumoClient(env=env)
         >>> case = sumo.CaseOnDisk(
@@ -47,7 +47,7 @@ class CaseOnDisk(SumoCase):
 
         After initialization, files must be explicitly indexed into the CaseOnDisk object:
 
-        >>> case.add_files(search_path)
+        >>> case.add_files(case_path)
 
         When initialized, the case can be uploaded to Sumo:
 

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -62,12 +62,12 @@ class CaseOnDisk(SumoCase):
     def __init__(
         self,
         case_metadata_path: str,
-        casepath,
         sumoclient,
         verbosity=logging.WARNING,
         sumo_mode="copy",
         config_path="fmuconfig/output/global_variables.yml",
         parameters_path="parameters.txt",
+        casepath="path/to/casepath",
     ):
         """Initialize CaseOnDisk.
 
@@ -85,12 +85,12 @@ class CaseOnDisk(SumoCase):
         case_metadata = _load_case_metadata(case_metadata_path)
         super().__init__(
             case_metadata,
-            casepath,
             sumoclient,
             verbosity,
             sumo_mode,
             config_path,
             parameters_path,
+            casepath,
         )
 
         self._sumo_logger = sumoclient.getLogger("fmu-sumo-uploader")

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -253,6 +253,7 @@ class CaseOnDisk(SumoCase):
         except IndexError as e:
             logger.debug(f"IndexError while accessing manifest: {e}")
 
+        # When the manifest and sumo uploads log has a mismatch, like manifest is overwritten, reupload from index 0.
         return 0
 
 

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -85,7 +85,6 @@ def main() -> None:
 
     # Legacy? Still needed?
     args.casepath = os.path.expandvars(args.casepath)
-    args.searchpath = os.path.expandvars(args.searchpath)
 
     _check_arguments(args)
 
@@ -142,8 +141,7 @@ def sumo_upload_main(
             parameters_path,
         )
         # add files to the case on disk object
-        logger.info("Adding files. Search path is %s", searchpath)
-        e.add_files(searchpath)
+        e.add_files(casepath)
         logger.info("%s files has been added", str(len(e.files)))
 
         if len(e.files) == 0:
@@ -155,6 +153,8 @@ def sumo_upload_main(
         logger.info("Starting upload")
         e.upload(threads=threads)
         logger.info("Upload done")
+        e.update_sumo_uploads(casepath)
+
     except Exception as err:
         err = err.with_traceback(None)
         logger.warning(f"Problem related to Sumo upload: {err} {type(err)}")
@@ -210,7 +210,8 @@ def _get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "searchpath",
         type=str,
-        help="path relative to runpath for files to upload",
+        help="The searchpath argument is deprecated and will be ignored in future versions.",
+        nargs="?",
     )
     parser.add_argument("env", type=str, help="Sumo environment to use.")
     parser.add_argument(
@@ -271,6 +272,12 @@ def _check_arguments(args) -> None:
 
     if not Path(args.casepath).exists():
         raise ValueError("Provided case path does not exist")
+
+    if args.searchpath is not None:
+        warnings.warn(
+            "The 'searchpath' argument is deprecated and will be ignored in a future version.",
+            DeprecationWarning,
+        )
 
     logger.debug("check_arguments() has ended")
 

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -53,19 +53,17 @@ and normally set to ``prod``.
 and normally set to ``<SCRATCH>/<USER>/<CASE_DIR>``
 e.g. ``/scratch/myfield/myuser/mycase/``
 
-Note! Filenames produced by FMU workflows use "--" as separator. Avoid this
-string in searchpaths, as it will cause following text to be parsed as a comment.
+Note! Filenames produced by FMU workflows use "--" as separator.
 
 FORWARD_MODEL example::
 
   FORWARD_MODEL XX -- Some other job that makes data
-  FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/maps/*.gri")
-  FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/polygons/*.csv")
+  FORWARD_MODEL SUMO_UPLOAD
 
 WORKFLOW_JOB example::
 
   <MY_JOB> -- The workflow job that creates data
-  SUMO_UPLOAD <SUMO_CASEPATH> "<SUMO_CASEPATH>/share/observations/maps/*.gri"  <SUMO_ENV>
+  SUMO_UPLOAD <SUMO_CASEPATH> <SUMO_ENV>
 
 """
 

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -132,12 +132,12 @@ def sumo_upload_main(
 
         e = uploader.CaseOnDisk(
             case_metadata_path,
-            casepath,
             sumoclient,
             verbosity,
             sumo_mode,
             config_path,
             parameters_path,
+            casepath,
         )
         # add files to the case on disk object
         e.add_files()

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -132,6 +132,7 @@ def sumo_upload_main(
 
         e = uploader.CaseOnDisk(
             case_metadata_path,
+            casepath,
             sumoclient,
             verbosity,
             sumo_mode,
@@ -139,7 +140,7 @@ def sumo_upload_main(
             parameters_path,
         )
         # add files to the case on disk object
-        e.add_files(casepath)
+        e.add_files()
         logger.info("%s files has been added", str(len(e.files)))
 
         if len(e.files) == 0:
@@ -151,7 +152,6 @@ def sumo_upload_main(
         logger.info("Starting upload")
         e.upload(threads=threads)
         logger.info("Upload done")
-        e.update_sumo_uploads(casepath)
 
     except Exception as err:
         err = err.with_traceback(None)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-import datetime
 
 import pytest
 import xtgeo
@@ -15,8 +15,8 @@ import yaml
 from sumo.wrapper import SumoClient
 
 from fmu.dataio import CreateCaseMetadata, ExportData
-from fmu.sumo import uploader
 from fmu.dataio.manifest import get_manifest_path
+from fmu.sumo import uploader
 
 if not sys.platform.startswith("darwin") and sys.version_info < (3, 12):
     import openvds
@@ -182,7 +182,7 @@ def test_manifest(token, case_metadata, surface_file, manifest_file):
     """Assert that manifest exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
 
-    case = uploader.CaseOnDisk(
+    uploader.CaseOnDisk(
         case_metadata_path=case_metadata,
         casepath=CASEPATH,
         sumoclient=sumoclient,

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -194,11 +194,13 @@ def test_manifest(token, case_metadata, surface_file, manifest_file):
 
     with open(manifest_file, "r") as f:
         manifest = json.load(f)
-    
+
     assert len(manifest) == 1
 
 
-def test_sumo_uploads(token, case_metadata, surface_file, manifest_file, sumo_uploads_file):
+def test_sumo_uploads(
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+):
     """Assert that sumo uploads log exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
 
@@ -209,30 +211,32 @@ def test_sumo_uploads(token, case_metadata, surface_file, manifest_file, sumo_up
         verbosity="DEBUG",
     )
 
-    # Assert that manifest is there, and assert that sumo uploads log is not there. 
+    # Assert that manifest is there, and assert that sumo uploads log is not there.
     assert os.path.exists(manifest_file)
     assert not os.path.exists(sumo_uploads_file)
 
     case.register()
     case.add_files()
     assert len(case.files) == 1
-    
+
     case.upload()
 
     # Assert that sumo uploads log is there.
     assert os.path.exists(sumo_uploads_file)
-    
+
     with open(manifest_file, "r") as f:
         manifest = json.load(f)
-    
+
     with open(sumo_uploads_file, "r") as f:
         sumo_uploads = json.load(f)
-    
+
     assert len(sumo_uploads) == 1
     assert sumo_uploads[-1]["last_index_manifest"] == len(manifest) - 1
 
 
-def test_upload_without_registration(token, case_metadata, surface_file, manifest_file, sumo_uploads_file):
+def test_upload_without_registration(
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+):
     """Assert that attempting to upload to a non-existing/un-registered case gives warning."""
     sumoclient = SumoClient(env=ENV, token=token)
 
@@ -250,7 +254,7 @@ def test_upload_without_registration(token, case_metadata, surface_file, manifes
     with pytest.warns(UserWarning, match="Case is not registered"):
         case.upload(threads=1)
 
-    # Assert if sumo uploads log is not there.    
+    # Assert if sumo uploads log is not there.
     assert not os.path.exists(sumo_uploads_file)
 
 
@@ -304,7 +308,12 @@ def test_case(token, case_metadata):
 
 
 def test_case_with_restricted_child(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file, sumo_uploads_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """Assert that uploading a child with 'classification: restricted' works.
     Assumes that the identity running this test have enough rights for that."""
@@ -327,7 +336,9 @@ def test_case_with_restricted_child(
     parsed_yaml["access"]["classification"] = "restricted"
 
     basename = os.path.dirname(surface_file)
-    restricted_metadata_file = os.path.join(basename, ".surface_restricted.bin.yml")
+    restricted_metadata_file = os.path.join(
+        basename, ".surface_restricted.bin.yml"
+    )
     with open(restricted_metadata_file, "w") as f:
         yaml.dump(parsed_yaml, f)
 
@@ -341,8 +352,10 @@ def test_case_with_restricted_child(
     # Make new export manifest with entry for restricted file
     new_entry = {
         "absolute_path": surface_file_copy,
-        "exported_at": datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z'),
-        "exported_by": "TEST"
+        "exported_at": datetime.datetime.now(datetime.UTC)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "exported_by": "TEST",
     }
 
     with open(manifest_file, "r") as f:
@@ -369,7 +382,9 @@ def test_case_with_restricted_child(
     os.remove(restricted_metadata_file)
 
 
-def test_case_with_one_child(token, case_metadata, surface_file, manifest_file, sumo_uploads_file):
+def test_case_with_one_child(
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+):
     """Upload one file to Sumo. Assert that it is there."""
 
     sumoclient = SumoClient(env=ENV, token=token)
@@ -407,7 +422,7 @@ def test_case_with_one_child_and_parameters_txt(
     surface_file,
     surface_metadata_file,
     manifest_file,
-    sumo_uploads_file
+    sumo_uploads_file,
 ):
     """Upload one file to Sumo. Assert that it is there."""
 
@@ -487,7 +502,12 @@ def test_case_with_one_child_and_parameters_txt(
 
 
 def test_case_with_one_child_with_affiliate_access(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file, sumo_uploads_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """Upload one file to Sumo with affiliate access.
     Assert that it is there."""
@@ -506,22 +526,28 @@ def test_case_with_one_child_with_affiliate_access(
     with open(surface_metadata_file) as f:
         parsed_yaml = yaml.safe_load(f)
     parsed_yaml["access"]["affiliate_roles"] = ["DROGON-AFFILIATE"]
-    affiliate_access_metadata_file = os.path.join(os.path.dirname(surface_file), ".surface_affiliate.bin.yml")
+    affiliate_access_metadata_file = os.path.join(
+        os.path.dirname(surface_file), ".surface_affiliate.bin.yml"
+    )
     with open(affiliate_access_metadata_file, "w") as f:
         yaml.dump(parsed_yaml, f)
 
     # Make copy of binary to match the modified metadata file
-    surface_file_copy = os.path.join(os.path.dirname(surface_file),"surface_affiliate.bin")
+    surface_file_copy = os.path.join(
+        os.path.dirname(surface_file), "surface_affiliate.bin"
+    )
     shutil.copy(
         surface_file,
         surface_file_copy,
     )
-    
+
     # Make new export manifest with entry for file with affilate access
     new_entry = {
         "absolute_path": surface_file_copy,
-        "exported_at": datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z'),
-        "exported_by": "TEST"
+        "exported_at": datetime.datetime.now(datetime.UTC)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "exported_by": "TEST",
     }
 
     with open(manifest_file, "r") as f:
@@ -579,9 +605,7 @@ def test_case_with_no_children(token, case_metadata):
         for _ in warnings_record:
             assert len(warnings_record) == 1, warnings_record
             assert (
-                warnings_record[0]
-                .message.args[0]
-                .startswith("No files found")
+                warnings_record[0].message.args[0].startswith("No files found")
             )
 
     total = _hits_for_case(sumoclient, e.fmu_case_uuid)
@@ -596,7 +620,9 @@ def test_case_with_no_children(token, case_metadata):
     os.remove(manifest_file)
 
 
-def test_missing_child_metadata(token, case_metadata, surface_file, manifest_file, sumo_uploads_file):
+def test_missing_child_metadata(
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+):
     """
     Try to upload files where one does not have metadata. Assert that warning is given
     and that upload commences with the other files. Check that the children are present.
@@ -611,18 +637,19 @@ def test_missing_child_metadata(token, case_metadata, surface_file, manifest_fil
     e.register()
 
     # Make a copy of the surface without copying companion metadata
-    surface_file_copy= os.path.join(os.path.dirname(surface_file), "surface_no_metadata.bin")
-    shutil.copy(
-        surface_file,
-        surface_file_copy
+    surface_file_copy = os.path.join(
+        os.path.dirname(surface_file), "surface_no_metadata.bin"
     )
+    shutil.copy(surface_file, surface_file_copy)
 
-    new_entry =  {
+    new_entry = {
         "absolute_path": surface_file_copy,
-        "exported_at": datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z'),
+        "exported_at": datetime.datetime.now(datetime.UTC)
+        .isoformat()
+        .replace("+00:00", "Z"),
         "exported_by": "TEST",
     }
-    
+
     # Append entry for file missing metadata in export manifest
     with open(manifest_file, "r") as f:
         manifest = json.load(f)
@@ -687,7 +714,9 @@ def test_invalid_yml_in_case_metadata(token):
             )
 
 
-def test_invalid_yml_in_child_metadata(token, case_metadata, surface_file, manifest_file, sumo_uploads_file):
+def test_invalid_yml_in_child_metadata(
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+):
     """
     Try to upload child with invalid yml in its metadata file.
     """
@@ -713,16 +742,16 @@ def test_invalid_yml_in_child_metadata(token, case_metadata, surface_file, manif
     )
 
     # Create new entry in export manifest
-    new_entry =  {
-            "absolute_path": str(Path.cwd() / "tests/data/surface_invalid.bin"),
-            "exported_at": "2025-07-22T08:07:52.197429Z",
-            "exported_by": "TEST",
-        }
+    new_entry = {
+        "absolute_path": str(Path.cwd() / "tests/data/surface_invalid.bin"),
+        "exported_at": "2025-07-22T08:07:52.197429Z",
+        "exported_by": "TEST",
+    }
 
     with open(manifest_file, "r") as f:
         manifest = json.load(f)
         manifest.append(new_entry)
-    
+
     os.remove(manifest_file)
 
     with open(manifest_file, "w") as f:
@@ -771,7 +800,12 @@ def test_schema_error_in_case(token, case_metadata):
 
 
 def test_schema_error_in_child(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file, sumo_uploads_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """
     Try to upload files where one does have metadata with error. Assert that warning is given
@@ -806,13 +840,13 @@ def test_schema_error_in_child(
         error_surface_file,
     )
 
-     # Create new entry in export manifest
+    # Create new entry in export manifest
     absolute_path = str(Path.cwd() / "tests/data/surface_error.bin")
-    new_entry =  {
-            "absolute_path": absolute_path,
-            "exported_at": "2024-01-01T08:07:52.197429Z",
-            "exported_by": "TEST",
-        }
+    new_entry = {
+        "absolute_path": absolute_path,
+        "exported_at": "2024-01-01T08:07:52.197429Z",
+        "exported_by": "TEST",
+    }
 
     with open(manifest_file, "r") as f:
         manifest = json.load(f)
@@ -848,7 +882,14 @@ def test_schema_error_in_child(
     os.remove(error_metadata_file)
 
 
-def test_multiple_exports_to_manifest_append_to_sumo_uploads(token, case_metadata, surface_file, surface_metadata_file, manifest_file, sumo_uploads_file):
+def test_multiple_exports_to_manifest_append_to_sumo_uploads(
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
+):
     """
     Upload new files added to the export manifest and new entry should be appended to the Sumo uploads log.
     """
@@ -874,14 +915,20 @@ def test_multiple_exports_to_manifest_append_to_sumo_uploads(token, case_metadat
     assert len(sumo_uploads) == 1
 
     # Create new entry in export manifest
-    metadata_file_copy = os.path.join(os.path.dirname(surface_file), ".surface_copy.bin.yml")
-    surface_file_copy = os.path.join(os.path.dirname(surface_file), "surface_copy.bin")
+    metadata_file_copy = os.path.join(
+        os.path.dirname(surface_file), ".surface_copy.bin.yml"
+    )
+    surface_file_copy = os.path.join(
+        os.path.dirname(surface_file), "surface_copy.bin"
+    )
     shutil.copy(surface_metadata_file, metadata_file_copy)
     shutil.copy(surface_file, surface_file_copy)
 
-    new_entry =  {
+    new_entry = {
         "absolute_path": surface_file_copy,
-        "exported_at": datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z'),
+        "exported_at": datetime.datetime.now(datetime.UTC)
+        .isoformat()
+        .replace("+00:00", "Z"),
         "exported_by": "TEST",
     }
 
@@ -893,7 +940,6 @@ def test_multiple_exports_to_manifest_append_to_sumo_uploads(token, case_metadat
     with open(manifest_file, "w") as f:
         json.dump(manifest, f, indent=4)
 
-
     # Assert that there is 1 new file added.
     e.add_files()
     assert len(e.files) == 2
@@ -903,10 +949,10 @@ def test_multiple_exports_to_manifest_append_to_sumo_uploads(token, case_metadat
 
     with open(sumo_uploads_file, "r") as f:
         sumo_uploads = json.load(f)
-    
+
     with open(manifest_file, "r") as f:
         manifest = json.load(f)
-    
+
     assert len(sumo_uploads) == 2
     assert sumo_uploads[-1]["last_index_manifest"] == len(manifest) - 1
 
@@ -1083,7 +1129,12 @@ def test_seismic_openvds_file(token, case_metadata, segy_file):
     reason="do not run on windows due to file-path differences",
 )
 def test_sumo_mode_default(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file, sumo_uploads_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """
     Test that SUMO_MODE defaults to copy, i.e. not deleting file after upload.
@@ -1124,7 +1175,12 @@ def test_sumo_mode_default(
     reason="do not run on windows due to file-path differences",
 )
 def test_sumo_mode_copy(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file, sumo_uploads_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """
     Test SUMO_MODE=copy, i.e. not deleting file after upload.


### PR DESCRIPTION
Linked issue: https://github.com/equinor/sumo/issues/238

- Get export manifest file using get_manifest_path method from dataio.
- Deprecate `searchpath`. If search path is provided, it will be ignored and use manifest for uploading instead. 
- Add a new parameter `casepath` to class `SumoCase`. 
- Upload files based on export manifest. 
        
       //Previously user has to define several SUMO_UPLOAD forward model with a searchpath in their config. for example,

        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/tables/*.csv")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/maps/*.gri")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/volumes/*.csv")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/polygons/*.csv")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/grids/*.roff")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/observations/seismic/*.segy")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/seismic/*.segy")
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/tables/inplace_volumes/*.parquet")  -- upload standard result: inplace_volumes
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/polygons/field_outline/*.parquet")  -- upload standard result: field_outline
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/maps/structure_depth_surface/*.gri")  -- upload standard result: structure_depth_surface
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/maps/structure_depth_isochore/*.gri")  -- upload standard result: structure_depth_isochore
        FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/polygons/structure_depth_fault_lines/*.parquet")  -- upload standard result: structure_depth_fault_lines
       
        
        //Now it simplifies to,

        FORWARD_MODEL SUMO_UPLOAD


- Fix failing tests