### PR TITLE
feat: allow searchpath but still give deprecation warning

### DIFF
--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -30,6 +30,7 @@ class SumoCase:
         config_path="fmuconfig/output/global_variables.yml",
         parameters_path="parameters.txt",
         casepath="path/to/casepath",
+        searchpath=None,
     ):
         logger.setLevel(verbosity)
         self.sumoclient = sumoclient
@@ -43,6 +44,7 @@ class SumoCase:
         logger.debug("self._sumo_parent_id is %s", self._sumo_parent_id)
         self._files = []
         self.sumo_mode = sumo_mode
+        self.searchpath = searchpath
 
         return
 
@@ -155,7 +157,9 @@ class SumoCase:
         if len(ok_uploads) > 0:
             upload_statistics = _calculate_upload_stats(ok_uploads)
             logger.info(upload_statistics)
-            self._update_sumo_uploads()
+            if self.searchpath is None:
+                # If using manifest: update .sumo_uploads
+                self._update_sumo_uploads()
 
         if rejected_uploads:
             logger.info(

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -83,6 +83,7 @@ def main() -> None:
 
     # Legacy? Still needed?
     args.casepath = os.path.expandvars(args.casepath)
+    # args.searchpath = os.path.expandvars(args.searchpath)
 
     _check_arguments(args)
 
@@ -138,6 +139,7 @@ def sumo_upload_main(
             config_path,
             parameters_path,
             casepath,
+            searchpath,
         )
         # add files to the case on disk object
         e.add_files()
@@ -274,7 +276,7 @@ def _check_arguments(args) -> None:
     if args.searchpath is not None:
         warnings.warn(
             "The 'searchpath' argument is deprecated and will be ignored in a future version.",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     logger.debug("check_arguments() has ended")


### PR DESCRIPTION
Keeping this feature ready in case some workflows break when Komodo 2025-09 is released.
The release includes the "manifest upload" (https://github.com/equinor/fmu-sumo-uploader/pull/152) and ignores search path.
In theory, few or no workflows should break with the change. However, if some workflow does some rogue moving of data or similar then they might not work anymore.

This PR allows still using the `searchpath` parameter instead of completely ignoring it.