### PR TITLE
fix: openvds checks and json strings in logs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "azure.storage.blob",
   "fmu-dataio",
   "httpx>=0.24.1",
-  "OpenVDS; sys_platform != 'darwin'",
+  "OpenVDS; sys_platform != 'darwin' and python_version < '3.12'",
   "ert; sys_platform != 'win32'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "azure.storage.blob",
   "fmu-dataio",
   "httpx>=0.24.1",
-  "OpenVDS; sys_platform != 'darwin' and python_version < '3.12'",
+  "OpenVDS; sys_platform != 'darwin'",
   "ert; sys_platform != 'win32'",
 ]
 

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -254,7 +254,7 @@ class SumoCase:
 def _get_log_msg(sumo_parent_id, status):
     """Return a suitable logging for upload issues."""
 
-    json = {
+    obj = {
         "upload_issue": {
             "case_uuid": str(sumo_parent_id),
             "filepath": str(status.get("blob_file_path")),
@@ -274,7 +274,7 @@ def _get_log_msg(sumo_parent_id, status):
             },
         }
     }
-    return json
+    return json.dumps(obj)
 
 
 def _calculate_upload_stats(uploads):


### PR DESCRIPTION
- ~~fix: We actually have OpenVDS for Python 3.12, so remove exclusion.~~
- fix: format objects as json for logging.