### PR TITLE
fix: log failed and rejected uploads with severity = ERROR

### DIFF
--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -174,7 +174,7 @@ class SumoCase:
                     f"Blob: [{u.get('blob_upload_response_status_code')}] "
                     f"{u.get('blob_upload_response_status_text')}"
                 )
-                self._sumo_logger.info(
+                self._sumo_logger.error(
                     _get_log_msg(self.sumo_parent_id, u),
                     extra={"objectUuid": self._sumo_parent_id},
                 )
@@ -196,7 +196,7 @@ class SumoCase:
                     f"Blob: [{u.get('blob_upload_response_status_code')}] "
                     f"{u.get('blob_upload_response_status_text')}"
                 )
-                self._sumo_logger.info(
+                self._sumo_logger.error(
                     _get_log_msg(self.sumo_parent_id, u),
                     extra={"objectUuid": self._sumo_parent_id},
                 )


### PR DESCRIPTION
Failed and rejected uploads currently get logged with level "INFO". Change this to "ERROR". 

Example Drogon case in `dev` env: `ce30ecf3-b2c9-4dec-9b28-fb9863e33c17`