### PR TITLE
fix: surfaces from komodo test

### DIFF
--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -26,11 +26,8 @@ def get_parameter_file(parameters_path, config_path):
     """Return a parameters object from the parameters.txt file
 
     Args:
-        case_uuid (str): parent uuid for case
-        realization_id (str): the id of the realization
         parameters_path (str): path to the parameters.txt file
         config_path (str): path to the fmu config file
-        sumoclient (SumoClient): Initialized sumo client for performing query
 
     Returns:
         SumoFile: parameters ready for upload, or None

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -68,7 +68,7 @@ def _get_suitable_cases(explorer):
     recently"""
     cases = explorer.cases
     cases = cases.filter(user="f_scout_ci")
-    assert len(cases) > 0
+    assert len(cases) > 0, "Found no cases uploaded by f_scout_ci"
     selected = []
     an_hour_ago = datetime.now(timezone.utc) + timedelta(hours=-1)
     a_day_ago = datetime.now(timezone.utc) + timedelta(hours=-24)

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -128,7 +128,6 @@ def test_case_surfaces(explorer: Explorer):
         for surf in case.surfaces:
             assert surf.uuid
             assert surf.name
-            assert surf.tagname
             if surf.metadata.get("fmu").get("aggregation") is not None:
                 continue
             if surf.ensemble is not None:


### PR DESCRIPTION
Surfaces can have `tagname=""` so `assert surf.tagname` will fail the test incorrectly.

Included a couple of small cleanup fixes