### PR TITLE
fix: CreateCaseMetadata has been renamed to ExportCaseMetadata

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/format_and_lint.yaml
+++ b/.github/workflows/format_and_lint.yaml
@@ -17,7 +17,7 @@ jobs:
       
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       
       - name: Installing dependencies

--- a/.github/workflows/run_tests_on_uploads_from_komodo.yaml
+++ b/.github/workflows/run_tests_on_uploads_from_komodo.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         os: [ubuntu-latest]
     permissions:
       contents: read

--- a/.github/workflows/run_uploader_tests.yaml
+++ b/.github/workflows/run_uploader_tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
         os: [ubuntu-latest]
     permissions:
       contents: read

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -193,7 +193,7 @@ def test_initialization(token, case_metadata):
     )
 
 
-def test_manifest(token, case_metadata, surface_file, manifest_file):
+def test_manifest(token, case_metadata, manifest_file):
     """Assert that manifest exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
 
@@ -213,9 +213,7 @@ def test_manifest(token, case_metadata, surface_file, manifest_file):
     assert len(manifest) == 1
 
 
-def test_sumo_uploads(
-    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
-):
+def test_sumo_uploads(token, case_metadata, manifest_file, sumo_uploads_file):
     """Assert that sumo uploads log exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
 
@@ -328,12 +326,7 @@ def test_case(token, case_metadata):
 
 
 def test_case_with_restricted_child(
-    token,
-    case_metadata,
-    surface_file,
-    surface_metadata_file,
-    manifest_file,
-    sumo_uploads_file,
+    token, case_metadata, surface_file, surface_metadata_file, manifest_file
 ):
     """Assert that uploading a child with 'classification: restricted' works.
     Assumes that the identity running this test have enough rights for that."""
@@ -522,12 +515,7 @@ def test_case_with_one_child_and_parameters_txt(
 
 
 def test_case_with_one_child_with_affiliate_access(
-    token,
-    case_metadata,
-    surface_file,
-    surface_metadata_file,
-    manifest_file,
-    sumo_uploads_file,
+    token, case_metadata, surface_file, surface_metadata_file, manifest_file
 ):
     """Upload one file to Sumo with affiliate access.
     Assert that it is there."""
@@ -730,7 +718,7 @@ def test_invalid_yml_in_case_metadata(token):
 
 
 def test_invalid_yml_in_child_metadata(
-    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+    token, case_metadata, surface_file, manifest_file
 ):
     """
     Try to upload child with invalid yml in its metadata file.

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -12,7 +12,8 @@ from pathlib import Path
 import pytest
 import xtgeo
 import yaml
-from fmu.dataio import CreateCaseMetadata, ExportData
+from fmu.dataio import ExportData
+from fmu.dataio._workflows.case.export_case_metadata import ExportCaseMetadata
 from fmu.dataio.manifest import get_manifest_path
 from sumo.wrapper import SumoClient
 
@@ -35,7 +36,7 @@ def fixture_case_metadata():
     global_variables_file = "tests/data/global_variables.yml"
     with open(global_variables_file) as f:
         global_vars = yaml.safe_load(f)
-    case_metadata_file = CreateCaseMetadata(
+    case_metadata_file = ExportCaseMetadata(
         config=global_vars,
         rootfolder="tests/data/",
         casename="TestCase from fmu-sumo-uploader",

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -193,6 +193,7 @@ def test_initialization(token, case_metadata):
     )
 
 
+# surface_file must be included for the manifest file to be created
 def test_manifest(token, case_metadata, surface_file, manifest_file):
     """Assert that manifest exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
@@ -213,6 +214,7 @@ def test_manifest(token, case_metadata, surface_file, manifest_file):
     assert len(manifest) == 1
 
 
+# surface_file must be included for the manifest file to be created
 def test_sumo_uploads(
     token, case_metadata, surface_file, manifest_file, sumo_uploads_file
 ):

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -193,7 +193,7 @@ def test_initialization(token, case_metadata):
     )
 
 
-def test_manifest(token, case_metadata, manifest_file):
+def test_manifest(token, case_metadata, surface_file, manifest_file):
     """Assert that manifest exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
 
@@ -213,7 +213,9 @@ def test_manifest(token, case_metadata, manifest_file):
     assert len(manifest) == 1
 
 
-def test_sumo_uploads(token, case_metadata, manifest_file, sumo_uploads_file):
+def test_sumo_uploads(
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
+):
     """Assert that sumo uploads log exists after exporting data"""
     sumoclient = SumoClient(env=ENV, token=token)
 
@@ -326,7 +328,12 @@ def test_case(token, case_metadata):
 
 
 def test_case_with_restricted_child(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """Assert that uploading a child with 'classification: restricted' works.
     Assumes that the identity running this test have enough rights for that."""
@@ -515,7 +522,12 @@ def test_case_with_one_child_and_parameters_txt(
 
 
 def test_case_with_one_child_with_affiliate_access(
-    token, case_metadata, surface_file, surface_metadata_file, manifest_file
+    token,
+    case_metadata,
+    surface_file,
+    surface_metadata_file,
+    manifest_file,
+    sumo_uploads_file,
 ):
     """Upload one file to Sumo with affiliate access.
     Assert that it is there."""
@@ -718,7 +730,7 @@ def test_invalid_yml_in_case_metadata(token):
 
 
 def test_invalid_yml_in_child_metadata(
-    token, case_metadata, surface_file, manifest_file
+    token, case_metadata, surface_file, manifest_file, sumo_uploads_file
 ):
     """
     Try to upload child with invalid yml in its metadata file.


### PR DESCRIPTION
`CreateCaseMetadata` has been renamed to `ExportCaseMetadata` in `fmu-dataio`: https://github.com/equinor/fmu-dataio/pull/1561

Update the import in our tests.

Also snuck in a change to remove testing on Python 3.11. Everyone should be on 3.12 now, so no need to keep testing 3.11