### PR TITLE
feat: use -u option with sumo_login

### DIFF
--- a/src/fmu/sumo/uploader/forward_models/__init__.py
+++ b/src/fmu/sumo/uploader/forward_models/__init__.py
@@ -49,12 +49,12 @@ class SumoUpload(ForwardModelStepPlugin):
             raise ForwardModelStepValidationError(
                 f"Invalid value for environment variable 'SUMO_ENV': {env}. Valid values are preview, dev, test and prod."
             )
-        command = f"sumo_login -e {env} -m silent"
+        command = f"sumo_login -e {env} -m silent -u"
         return_code = subprocess.call(command, shell=True)
 
         err_msg = (
             "Your access token for Sumo is either missing or expired. "
-            "Please run 'sumo_login' in a terminal window to log in again."
+            "Please run 'sumo_login -u' in a terminal window to log in again."
         )
 
         if return_code != 0:


### PR DESCRIPTION
feat: use -u option with `sumo_login` to make authentication use dedicated `fmu-sumo-uploader` client app registration.