### PR TITLE
chore: upgrade github actions versions

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -22,10 +22,10 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/format_and_lint.yaml
+++ b/.github/workflows/format_and_lint.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/run_tests_on_uploads_from_komodo.yaml
+++ b/.github/workflows/run_tests_on_uploads_from_komodo.yaml
@@ -17,17 +17,17 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure Login
-        uses: Azure/login@v2
+        uses: Azure/login@v3
         with:
           client-id: f96c150d-cacf-4257-9cc9-54b2c68ec4ce
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
           subscription-id: 87897772-fb27-495f-ae40-486a2df57baa
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run_uploader_tests.yaml
+++ b/.github/workflows/run_uploader_tests.yaml
@@ -17,17 +17,17 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure Login
-        uses: Azure/login@v2
+        uses: Azure/login@v3
         with:
           client-id: f96c150d-cacf-4257-9cc9-54b2c68ec4ce
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
           subscription-id: 87897772-fb27-495f-ae40-486a2df57baa
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
 ## Issue
Related to https://github.com/equinor/sumo-infrastructure/issues/190

## Description
Upgrade github actions versions to handle warnings:
<img width="1498" height="142" alt="image" src="https://github.com/user-attachments/assets/7289bcce-2eec-46f6-b96b-bd1af7cb3559" />


## How to test
Verify that the actions run without any version warnings.

Note: the tests are failing due to a breaking change in `fmu-settings` that also requires a new release of `fmu-dataio` https://equinor.slack.com/archives/C06E3UTGTEV/p1777536414838549

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅