### PR TITLE
chore: upgrade slack alert GitHub action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      target-branch: "main"
+      schedule:
+          interval: "monthly"
+      groups:
+          all-actions:
+              patterns:
+                  - "*"
+              update-types:
+                  - "minor"
+                  - "patch"

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify on Slack
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
 ## Issue
Related to https://github.com/equinor/sumo-infrastructure/issues/190

Previously updated some actions in https://github.com/equinor/fmu-sumo-uploader/pull/221
Missed update of the Slack github action.

## Description
Upgrade the Slack github action to newest version

## How to test
Verify that the actions run without any version warnings.

Note: the tests are failing due to a breaking change in `fmu-settings` that also requires a new release of `fmu-dataio` https://equinor.slack.com/archives/C06E3UTGTEV/p1777536414838549

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅