### PR TITLE
feat: for nodes in stjohn.statoil.no and rio.statoil.no, set batch_size to 1.

### DIFF
--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -138,6 +138,7 @@ async def _upload_files(
     Create threads and call _upload in each thread
     """
     batch_size = _get_batch_size()
+    logger.info(f"batch_size={batch_size}")
 
     for file in files:
         if "fmu" in file.metadata and "realization" in file.metadata["fmu"]:

--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -6,6 +6,7 @@ The function that uploads files.
 
 import asyncio
 import json
+import os
 from copy import deepcopy
 from pathlib import Path
 
@@ -112,6 +113,17 @@ def maybe_upload_realization_and_ensemble(sumoclient, base_metadata):
         sumoclient.post(f"/objects('{case_uuid}')", json=realization_metadata)
 
 
+def _get_batch_size():
+    nodename = os.uname().nodename
+    nameparts = nodename.split(".", 1)
+    domainname = nameparts[1] if len(nameparts) > 1 else ""
+    if domainname in ["rio.statoil.no", "stjohn.statoil.no"]:
+        batch_size = 1
+    else:
+        batch_size = 10
+    return batch_size
+
+
 async def _upload_files(
     files,
     sumoclient,
@@ -119,13 +131,13 @@ async def _upload_files(
     sumo_mode="copy",
     config_path="fmuconfig/output/global_variables.yml",
     parameters_path="parameters.txt",
-    batch_size=10,
 ):
     """
     Upload realization and ensemble objects if they do not exist
     Upload parameters file if it does not exist or it has changed
     Create threads and call _upload in each thread
     """
+    batch_size = _get_batch_size()
 
     for file in files:
         if "fmu" in file.metadata and "realization" in file.metadata["fmu"]:


### PR DESCRIPTION
 ## Issue
Closes #228 

## Description
Extract domain name for current node. If it is equal to `stjohn.statoil.no` or `rio.statoil.no`, set `batch_size` to 1. Otherwise, use 10.

## How to test
- Run test cases in StJohn and Rio. Look for the string "batch_size={N}" in the logs, and observe that `N` is `1`.
- Run test cases on another cluster, and observe that the `batch_size` is logged as `10`.

## Checklist
- [ ] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [ ] New/refactored code is following same conventions as the rest of the code base 🧬
- [ ] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [ ] Commits are semantic ✅