### PR TITLE
fix: verify client can authenticate before uploading

### DIFF
--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -12,6 +12,7 @@ import time
 import warnings
 
 from fmu.dataio.manifest import get_manifest_path
+import httpx
 from fmu.sumo.uploader._logger import get_uploader_logger
 from fmu.sumo.uploader._upload_files import upload_files
 
@@ -119,6 +120,17 @@ class SumoCase:
         logger.debug("files_to_upload: %s", files_to_upload)
 
         sumoclient = self.sumoclient.client_for_case(self._sumo_parent_id)
+
+        # TODO: Verify that case exists
+        try:
+            sumoclient.get(f"/objects/{self._sumo_parent_id}")
+        except Exception as err:
+            if (
+                isinstance(err, httpx.HTTPStatusError)
+                and err.response.status_code == 404
+            ):
+                print("Did not find the case on Sumo")
+            raise err
 
         upload_results = upload_files(
             files_to_upload,

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -12,7 +12,6 @@ import time
 import warnings
 
 from fmu.dataio.manifest import get_manifest_path
-import httpx
 from fmu.sumo.uploader._logger import get_uploader_logger
 from fmu.sumo.uploader._upload_files import upload_files
 
@@ -121,15 +120,13 @@ class SumoCase:
 
         sumoclient = self.sumoclient.client_for_case(self._sumo_parent_id)
 
-        # TODO: Verify that case exists
         try:
-            sumoclient.get(f"/objects/{self._sumo_parent_id}")
+            sumoclient.authenticate()
         except Exception as err:
-            if (
-                isinstance(err, httpx.HTTPStatusError)
-                and err.response.status_code == 404
-            ):
-                print("Did not find the case on Sumo")
+            logger.warning(
+                f"Failed to establish connection with Sumo for case {self._sumo_parent_id}. "
+                "This can happen if the case has not been registered in Sumo."
+            )
             raise err
 
         upload_results = upload_files(

--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -166,10 +166,34 @@ async def _upload_files(
 
             paramfile = get_parameter_file(parameters_path, config_path)
             if paramfile is not None:
+                # TODO: This search seems to be what fails with 401 when case objects doesn´t exist
                 query = f"fmu.case.uuid:{sumo_parent_id} AND fmu.realization.uuid:{realization_id} AND data.content:parameters"
                 search_res = sumoclient.get(
                     "/search", {"$query": query, "$select": "_sumo.blob_md5"}
                 ).json()
+                # search_res = sumoclient.post(
+                #     "/search",
+                #     json={
+                #         "query": {
+                #             "bool": {
+                #                 "must": [
+                #                     {
+                #                         "term": {
+                #                             "fmu.case.uuid": sumo_parent_id
+                #                         }
+                #                     },
+                #                     {
+                #                         "term": {
+                #                             "fmu.realization.uuid": realization_id
+                #                         }
+                #                     },
+                #                     {"term": {"data.content": "parameters"}},
+                #                 ]
+                #             }
+                #         },
+                #         "_source": ["_sumo.blob_md5"],
+                #     },
+                # ).json()
                 # Check if the parameters file does not exist or has changed
                 if (
                     search_res["hits"]["total"]["value"] == 0

--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -166,34 +166,10 @@ async def _upload_files(
 
             paramfile = get_parameter_file(parameters_path, config_path)
             if paramfile is not None:
-                # TODO: This search seems to be what fails with 401 when case objects doesn´t exist
                 query = f"fmu.case.uuid:{sumo_parent_id} AND fmu.realization.uuid:{realization_id} AND data.content:parameters"
                 search_res = sumoclient.get(
                     "/search", {"$query": query, "$select": "_sumo.blob_md5"}
                 ).json()
-                # search_res = sumoclient.post(
-                #     "/search",
-                #     json={
-                #         "query": {
-                #             "bool": {
-                #                 "must": [
-                #                     {
-                #                         "term": {
-                #                             "fmu.case.uuid": sumo_parent_id
-                #                         }
-                #                     },
-                #                     {
-                #                         "term": {
-                #                             "fmu.realization.uuid": realization_id
-                #                         }
-                #                     },
-                #                     {"term": {"data.content": "parameters"}},
-                #                 ]
-                #             }
-                #         },
-                #         "_source": ["_sumo.blob_md5"],
-                #     },
-                # ).json()
                 # Check if the parameters file does not exist or has changed
                 if (
                     search_res["hits"]["total"]["value"] == 0


### PR DESCRIPTION
 ## Issue
﻿﻿Closes https://github.com/equinor/sumo-core/issues/1036

## Description
Also requires https://github.com/equinor/sumo-wrapper-python/pull/266
Verify that `sumoclient` is able to authenticate properly before starting to upload.

## How to test
Run a Drogon case without the `--sumo` flag in `create_case_metadata`
Error message should be `404` instead of `401`

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅