### PR TITLE
fix: require sumo-wrapper-python>=1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "fmu-sumo-uploader"
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-  "sumo-wrapper-python>=1.0.3",
+  "sumo-wrapper-python>=1.7.0",
   "azure.storage.blob",
   "fmu-dataio>=2.26.0",
   "httpx>=0.24.1",


### PR DESCRIPTION
 ## Issue
Related to https://github.com/equinor/sumo-core/issues/1036

## Description
Sumo-wrapper was updated to not try interactive login when getting client for case: https://github.com/equinor/sumo-wrapper-python/pull/266
This PR updates the dependency on `sumo-wrapper-python` to ensure that the wrapper changes are installed.

## How to test
Run a Drogon case without the `--sumo` flag in create_case_metadata
Error message should be 404 instead of 401

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅