### PR TITLE
Feat/merge parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,10 @@ cython_debug/
 
 # VS Code
 .vscode/
+
+# Emacs
+*~
+.#*
+
+# MacOS
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "fmu-sumo-uploader"
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-  "sumo-wrapper-python>=1.7.0",
+  "sumo-wrapper-python>=1.8.0",
   "azure.storage.blob",
   "fmu-dataio>=2.26.0",
   "httpx>=0.24.1",

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -4,17 +4,19 @@ Base class for CaseOnJob and CaseOnDisk classes.
 
 """
 
-import datetime
 import json
 import os
 import statistics
 import time
 import warnings
-from typing import overload
 
 from fmu.dataio.manifest import get_manifest_path
 from fmu.sumo.uploader._logger import get_uploader_logger
 from fmu.sumo.uploader._upload_files import upload_files
+from fmu.sumo.uploader._utils import (
+    get_field_from_metadata,
+    sanitize_datetimes,
+)
 
 # pylint: disable=C0103 # allow non-snake case variable names
 
@@ -34,9 +36,9 @@ class SumoCase:
     ):
         logger.setLevel(verbosity)
         self.sumoclient = sumoclient
-        self.case_metadata = _sanitize_datetimes(case_metadata)
+        self.case_metadata = sanitize_datetimes(case_metadata)
         self.casepath = casepath
-        self._fmu_case_uuid = _get_field_from_metadata(
+        self._fmu_case_uuid = get_field_from_metadata(
             self.case_metadata, "fmu.case.uuid"
         )
         logger.debug("self._fmu_case_uuid is %s", self._fmu_case_uuid)
@@ -259,47 +261,3 @@ def _calculate_upload_stats(uploads):
     }
 
     return stats
-
-
-@overload
-def _sanitize_datetimes(data: dict) -> dict: ...
-@overload
-def _sanitize_datetimes(data: datetime.datetime) -> str: ...
-@overload
-def _sanitize_datetimes(data: list) -> list: ...
-def _sanitize_datetimes(data):
-    """Sanitize datetimes.
-
-    Given a dictionary, recursively find and replace all datetime objects
-    with isoformat string, so that it does not cause problems for
-    JSON later on."""
-
-    if isinstance(data, datetime.datetime):
-        return data.isoformat()
-    if isinstance(data, dict):
-        for key in data:
-            data[key] = _sanitize_datetimes(data[key])
-    elif isinstance(data, list):
-        data = [_sanitize_datetimes(element) for element in data]
-    return data
-
-
-def _get_field_from_metadata(case_metadata: dict, field_path: str):
-    """Traverse nested dict using a dot-separated field path
-
-    Return the value of the field if it exists, else None and log an error.
-
-    Given a case metadata dictionary and a field path in the form of
-    'fmu.case.uuid', return the value of the field if it exists, else None.
-    """
-
-    fields = field_path.split(".")
-    value = case_metadata
-
-    for field in fields:
-        if not isinstance(value, dict) or field not in value:
-            err_msg = f"Invalid metadata: Could not get {field_path} from case metadata"
-            warnings.warn(err_msg)
-            return None
-        value = value[field]
-    return value

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -37,7 +37,7 @@ def is_seismic(metadata):
 
 def is_parameters(metadata):
     return (
-        get_field_from_metadata(metadata, "data.standard_results")
+        get_field_from_metadata(metadata, "data.standard_result.name")
         == "parameters"
     )
 

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -154,8 +154,8 @@ async def upload_blob(blob_url, byte_string, retryer):
 @upload_response
 async def merge_parameters(sumoclient, object_id, byte_string, retry_strategy):
     """Merge parameters blob to Sumo and return a consistent response format"""
-    path = f"/objects('{object_id}')/merge"
-    response = await sumoclient.post_async(
+    path = f"/objects('{object_id}')/blob/merge"
+    response = await sumoclient.put_async(
         path=path,
         blob=byte_string,
         retry_strategy=retry_strategy,

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -19,6 +19,7 @@ from azure.storage.blob import BlobClient, ContentSettings
 from sumo.wrapper import RetryStrategy
 
 from fmu.sumo.uploader._logger import get_uploader_logger
+from fmu.sumo.uploader._utils import get_field_from_metadata
 
 _max_single_put_size = 4 * 1024 * 1024
 
@@ -28,10 +29,16 @@ logger = get_uploader_logger()
 
 
 def is_seismic(metadata):
+    return get_field_from_metadata(metadata, "data.format") in [
+        "openvds",
+        "segy",
+    ]
+
+
+def is_parameters(metadata):
     return (
-        metadata.get("data")
-        and metadata.get("data").get("format")
-        and metadata.get("data").get("format") in ["openvds", "segy"]
+        get_field_from_metadata(metadata, "data.standard_results")
+        == "parameters"
     )
 
 
@@ -142,6 +149,19 @@ async def upload_blob(blob_url, byte_string, retryer):
     # response has the form {'etag': '"0x8DCDC8EED1510CC"', 'last_modified': datetime.datetime(2024, 9, 24, 11, 49, 20, tzinfo=datetime.timezone.utc), 'content_md5': bytearray(b'\x1bPM3(\xe1o\xdf(\x1d\x1f\xb9Qm\xd9\x0b'), 'client_request_id': '08c962a4-7a6b-11ef-8710-acde48001122', 'request_id': 'f459ad2b-801e-007d-1977-0ef6ee000000', 'version': '2024-11-04', 'version_id': None, 'date': datetime.datetime(2024, 9, 24, 11, 49, 19, tzinfo=datetime.timezone.utc), 'request_server_encrypted': True, 'encryption_key_sha256': None, 'encryption_scope': None}
     # ... which is not what the caller expects, so we return something reasonable.
     return True
+
+
+@upload_response
+async def merge_parameters(sumoclient, object_id, byte_string, retry_strategy):
+    """Merge parameters blob to Sumo and return a consistent response format"""
+    path = f"/objects('{object_id}')/merge"
+    response = await sumoclient.post_async(
+        path=path,
+        blob=byte_string,
+        retry_strategy=retry_strategy,
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 @upload_response
@@ -316,7 +336,23 @@ class SumoFile:
 
         # UPLOAD BLOB
 
-        if is_seismic(self.metadata):
+        if is_parameters(self.metadata):
+            retries = [0]  # mutable object to store retry count in closure
+
+            def update_retries(retry_state):
+                retries[0] = retry_state.attempt_number
+
+            retry_strategy = RetryStrategy(before_sleep=update_retries)
+
+            result["blob_upload"] = await merge_parameters(
+                sumoclient,
+                self.sumo_object_id,
+                self.byte_string,
+                retry_strategy=retry_strategy,
+            )
+            result["blob_upload"].retries = retries[0]
+
+        elif is_seismic(self.metadata):
             logger.info(
                 "This is a seismic file, will attempt to upload as OpenVDS"
             )

--- a/src/fmu/sumo/uploader/_utils.py
+++ b/src/fmu/sumo/uploader/_utils.py
@@ -1,0 +1,44 @@
+import datetime
+from typing import overload
+
+
+@overload
+def sanitize_datetimes(data: dict) -> dict: ...
+@overload
+def sanitize_datetimes(data: datetime.datetime) -> str: ...
+@overload
+def sanitize_datetimes(data: list) -> list: ...
+def sanitize_datetimes(data):
+    """Sanitize datetimes.
+
+    Given a dictionary, recursively find and replace all datetime objects
+    with isoformat string, so that it does not cause problems for
+    JSON later on."""
+
+    if isinstance(data, datetime.datetime):
+        return data.isoformat()
+    if isinstance(data, dict):
+        for key in data:
+            data[key] = sanitize_datetimes(data[key])
+    elif isinstance(data, list):
+        data = [sanitize_datetimes(element) for element in data]
+    return data
+
+
+def get_field_from_metadata(metadata: dict, field_path: str):
+    """Traverse nested dict using a dot-separated field path
+
+    Return the value of the field if it exists, else None and log an error.
+
+    Given a case metadata dictionary and a field path in the form of
+    'fmu.case.uuid', return the value of the field if it exists, else None.
+    """
+
+    fields = field_path.split(".")
+    value = metadata
+
+    for field in fields:
+        if not isinstance(value, dict) or field not in value:
+            return None
+        value = value[field]
+    return value

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -18,7 +18,7 @@ from fmu.dataio.manifest import get_manifest_path
 from sumo.wrapper import SumoClient
 
 from fmu.sumo import uploader
-from fmu.sumo.uploader._sumocase import _get_field_from_metadata
+from fmu.sumo.uploader._utils import get_field_from_metadata
 from fmu.sumo.uploader.caseondisk import _load_case_metadata
 
 if not sys.platform.startswith("darwin"):
@@ -203,15 +203,14 @@ def _hits_for_case(sumoclient, case_uuid):
 
 
 def test_get_field_from_metadata(case_metadata):
-    asset_name = _get_field_from_metadata(case_metadata, "access.asset.name")
+    asset_name = get_field_from_metadata(case_metadata, "access.asset.name")
     assert asset_name == "Drogon"
 
 
 def test_get_field_from_metadata_invalid_field(case_metadata):
-    with pytest.warns(UserWarning, match="Invalid metadata"):
-        non_existent_field = _get_field_from_metadata(
-            case_metadata, "non.existing.field"
-        )
+    non_existent_field = get_field_from_metadata(
+        case_metadata, "non.existing.field"
+    )
     assert non_existent_field is None
 
 


### PR DESCRIPTION
 ## Issue
Closes #245 
## Description
Use the `/objects('{objectid}')/blob/merge` endpoint for merging the `parameters` blob, rather than uploading and overwriting directly to the blob store.

## How to test
Run a case (ensemble) with a few realizations, then re-run with a different subset. Verify that all realizations can be found in the blob (`parquet` file).

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [x] Documentation has been updated 🧾
- [ ] Commits are semantic ✅