### PR TITLE
fix: log size mismatches

### DIFF
--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -288,6 +288,15 @@ class SumoFile:
                 extra={"objectUuid": self.metadata["fmu"]["case"]["uuid"]},
             )
 
+        if file_size_bytes is not None and file_size_bytes == sumo_blob_size:
+            sumo_logger.warning(
+                "FileSizeTest: file.size_bytes (%s) differs from blob size (%s) for %s",
+                file_size_bytes,
+                sumo_blob_size,
+                file_meta["absolute_path"],
+                extra={"objectUuid": self.metadata["fmu"]["case"]["uuid"]},
+            )
+
     async def _delete_metadata(self, sumoclient, object_id):
         logger.warning("Deleting metadata object: %s", object_id)
         path = f"/objects('{object_id}')"

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -288,15 +288,6 @@ class SumoFile:
                 extra={"objectUuid": self.metadata["fmu"]["case"]["uuid"]},
             )
 
-        if file_size_bytes is not None and file_size_bytes == sumo_blob_size:
-            sumo_logger.warning(
-                "FileSizeTest: file.size_bytes (%s) differs from blob size (%s) for %s",
-                file_size_bytes,
-                sumo_blob_size,
-                file_meta["absolute_path"],
-                extra={"objectUuid": self.metadata["fmu"]["case"]["uuid"]},
-            )
-
     async def _delete_metadata(self, sumoclient, object_id):
         logger.warning("Deleting metadata object: %s", object_id)
         path = f"/objects('{object_id}')"

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -5,6 +5,7 @@ Base class for FileOnJob and FileOnDisk classes.
 """
 
 import functools
+import logging
 import math
 import os
 import re
@@ -25,6 +26,13 @@ _max_single_put_size = 4 * 1024 * 1024
 # pylint: disable=C0103 # allow non-snake case variable names
 
 logger = get_uploader_logger()
+
+
+def _get_sumo_logger(sumoclient):
+    sumo_logger = sumoclient.getLogger("fmu-sumo-uploader")
+    sumo_logger.setLevel(logging.INFO)
+    sumo_logger.propagate = False
+    return sumo_logger
 
 
 def is_seismic(metadata):
@@ -266,6 +274,20 @@ class SumoFile:
     def __init__(self):
         return
 
+    def _warn_on_blob_size_mismatch(self, sumo_logger):
+        file_meta = self.metadata.get("file", {})
+        file_size_bytes = file_meta.get("size_bytes")
+        sumo_blob_size = self.metadata["_sumo"]["blob_size"]
+
+        if file_size_bytes is not None and file_size_bytes != sumo_blob_size:
+            sumo_logger.warning(
+                "FileSizeDiscrepancy: file.size_bytes (%s) differs from blob size (%s) for %s",
+                file_size_bytes,
+                sumo_blob_size,
+                file_meta["absolute_path"],
+                extra={"objectUuid": self.metadata["fmu"]["case"]["uuid"]},
+            )
+
     async def _delete_metadata(self, sumoclient, object_id):
         logger.warning("Deleting metadata object: %s", object_id)
         path = f"/objects('{object_id}')"
@@ -276,6 +298,8 @@ class SumoFile:
         """Upload this file to Sumo"""
         # We need these included even if returning before blob upload
         result = {"blob_file_path": self.path, "blob_file_size": self._size}
+
+        self._warn_on_blob_size_mismatch(_get_sumo_logger(sumoclient))
 
         result["validation"] = await validate(sumo_parent_id, self.metadata)
         if not result["validation"].ok():


### PR DESCRIPTION
 ## Issue
Close #241 

## Description
Log file-size discrepancies in sumomessagelog

## How to test
- Verified a file with file.size_bytes != actual blob size produces a warning entry tied to the case UUID in sumomessagelog.
- Verified matching sizes produce no warning/log noise.

## Checklist
- [ ] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [ ] New/refactored code is following same conventions as the rest of the code base 🧬
- [ ] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [ ] Commits are semantic ✅