### PR TITLE
feat: always set ensemble and realization objects as internal

### DIFF
--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -100,6 +100,8 @@ def maybe_upload_realization_and_ensemble(sumoclient, base_metadata):
         realization_metadata["_sumo"] = {}
         realization_metadata["class"] = "realization"
         realization_metadata["fmu"]["context"]["stage"] = "realization"
+        # Realization and Ensemble objects should always be internal
+        realization_metadata["access"]["classification"] = "internal"
 
         case_uuid = realization_metadata["fmu"]["case"]["uuid"]
 


### PR DESCRIPTION
 ## Issue
https://github.com/equinor/sumo-core/issues/1104

## Description
A bug where users with read-only access were unable to read Realization (and Ensemble) objects that had `access.classification=restricted`
Sumo-core always treats `Case`, `Ensemble` and `Realization` objects as `internal`

This PR: always set `access.classification` to `internal` for Ensemble and Realization objects.

Note: With the bugfix https://github.com/equinor/sumo-core/pull/1105 in Sumo-core, this update is strictly not necessary, but it does make the mechanism more explicit.

## How to test
Run a case where all objects have `access.classification` set to restricted.
Verify that:
- All uploaded objects have `access.classification=restricted`
- All related Ensemble and Realization objects have `access.classification=internal`

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅