### PR TITLE
fix: log correct total file count to Sumo

### DIFF
--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -200,7 +200,7 @@ class SumoCase:
 
         details = {
             "case_uuid": self._fmu_case_uuid,
-            "total_files_count": len(self.files),
+            "total_files_count": len(files_to_upload),
             "ok_files": len(ok_uploads),
             "failed_files": len(failed_uploads),
             "rejected_files": len(rejected_uploads),

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -140,9 +140,7 @@ class SumoCase:
         md_retries, blob_retries = _get_retries(
             ok_uploads, failed_uploads, rejected_uploads
         )
-        print("---------- MD_RETRIES ----------")
-        print(md_retries)
-        print("---------- MD_RETRIES ----------")
+
         if len(md_retries) > 0 or len(blob_retries) > 0:
             self._sumo_logger.warning(
                 "UploadRetries: Some uploads required retries. Case %s, Ensemble %s, Realization %d. Metadata retries: %d, Blob retries: %d",
@@ -284,10 +282,6 @@ def _calculate_upload_stats(uploads):
     blob_upload_retries = [u["blob_upload"].retries for u in uploads]
     metadata_upload_times = [u["metadata_upload"].elapsed for u in uploads]
     metadata_upload_retries = [u["metadata_upload"].retries for u in uploads]
-
-    print("---------- metadata_upload_retries ----------")
-    print(metadata_upload_retries)
-    print("---------- metadata_upload_retries ----------")
 
     stats = {
         "blob": {

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -140,6 +140,9 @@ class SumoCase:
         md_retries, blob_retries = _get_retries(
             ok_uploads, failed_uploads, rejected_uploads
         )
+        print("---------- MD_RETRIES ----------")
+        print(md_retries)
+        print("---------- MD_RETRIES ----------")
         if len(md_retries) > 0 or len(blob_retries) > 0:
             self._sumo_logger.warning(
                 "UploadRetries: Some uploads required retries. Case %s, Ensemble %s, Realization %d. Metadata retries: %d, Blob retries: %d",
@@ -281,6 +284,10 @@ def _calculate_upload_stats(uploads):
     blob_upload_retries = [u["blob_upload"].retries for u in uploads]
     metadata_upload_times = [u["metadata_upload"].elapsed for u in uploads]
     metadata_upload_retries = [u["metadata_upload"].retries for u in uploads]
+
+    print("---------- metadata_upload_retries ----------")
+    print(metadata_upload_retries)
+    print("---------- metadata_upload_retries ----------")
 
     stats = {
         "blob": {

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -280,7 +280,7 @@ def _calculate_upload_stats(uploads):
     blob_upload_times = [u["blob_upload"].elapsed for u in uploads]
     blob_upload_retries = [u["blob_upload"].retries for u in uploads]
     metadata_upload_times = [u["metadata_upload"].elapsed for u in uploads]
-    metdata_upload_retries = [u["metadata_upload"].retries for u in uploads]
+    metadata_upload_retries = [u["metadata_upload"].retries for u in uploads]
 
     stats = {
         "blob": {
@@ -289,7 +289,7 @@ def _calculate_upload_stats(uploads):
         },
         "metadata": {
             "upload_time": _get_stats(metadata_upload_times),
-            "upload_retries": _get_stats(metdata_upload_retries),
+            "upload_retries": _get_stats(metadata_upload_retries),
         },
     }
 

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -167,7 +167,7 @@ class CaseOnDisk(SumoCase):
                     self._fmu_case_uuid
                 )
             except Exception as ex:
-                logger.warn(f"Unable to create shared access key: {ex}")
+                logger.warning(f"Unable to create shared access key: {ex}")
                 pass
 
             logger.info("Case registered. SumoID: {}".format(sumo_parent_id))


### PR DESCRIPTION
 ## Issue
N/A

## Description
https://github.com/equinor/fmu-sumo-uploader/pull/118 fixed an issue where incorrect file count was logged, but did not fix the count logged to Sumo messagelog.
This PR:
- Log correct total upload count to Sumo messagelog
- Fix a couple of typos

## How to test
Run Drogon and check summary in messagelog: Verify that `total_files_count` equals `ok_files`

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅