### PR TITLE
feat: add more info to upload details

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ exclude = [".env", ".git", ".github", ".venv", "venv"]
 line-length = 79
 
 [tool.ruff.lint]
-ignore = ["E501"]
+ignore = ["E501", "BLE001", "TRY002", "EXE001"]
 
 extend-select = [
   "C4",  # Flake8-comprehensions

--- a/src/fmu/sumo/uploader/_fileondisk.py
+++ b/src/fmu/sumo/uploader/_fileondisk.py
@@ -65,7 +65,6 @@ class FileOnDisk(SumoFile):
         self.dir_name = os.path.dirname(self.path)
 
         self.sumo_object_id = None
-        self.sumo_parent_id = None
 
         self.metadata["_sumo"] = {}
 

--- a/src/fmu/sumo/uploader/_fileondisk.py
+++ b/src/fmu/sumo/uploader/_fileondisk.py
@@ -64,8 +64,6 @@ class FileOnDisk(SumoFile):
         self.basename = os.path.basename(self.path)
         self.dir_name = os.path.dirname(self.path)
 
-        self._file_format = None
-
         self.sumo_object_id = None
         self.sumo_parent_id = None
 

--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -31,7 +31,6 @@ class FileOnJob(SumoFile):
         """
         self.metadata = metadata
         self._size = None
-        self._file_format = None
         self.sumo_object_id = None
         self.sumo_parent_id = None
 

--- a/src/fmu/sumo/uploader/_fileonjob.py
+++ b/src/fmu/sumo/uploader/_fileonjob.py
@@ -32,7 +32,6 @@ class FileOnJob(SumoFile):
         self.metadata = metadata
         self._size = None
         self.sumo_object_id = None
-        self.sumo_parent_id = None
 
         self.metadata["_sumo"] = {}
 

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -170,9 +170,9 @@ class SumoCase:
             )
 
             for u in rejected_uploads[0:4]:
-                logger.info(_get_log_msg(self.sumo_parent_id, u))
+                logger.info(_get_log_msg(self._sumo_parent_id, u))
                 self._sumo_logger.error(
-                    _get_log_msg(self.sumo_parent_id, u),
+                    _get_log_msg(self._sumo_parent_id, u),
                     extra={"objectUuid": self._sumo_parent_id},
                 )
 
@@ -182,9 +182,9 @@ class SumoCase:
             )
 
             for u in failed_uploads[0:4]:
-                logger.info(_get_log_msg(self.sumo_parent_id, u))
+                logger.info(_get_log_msg(self._sumo_parent_id, u))
                 self._sumo_logger.error(
-                    _get_log_msg(self.sumo_parent_id, u),
+                    _get_log_msg(self._sumo_parent_id, u),
                     extra={"objectUuid": self._sumo_parent_id},
                 )
 

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -198,8 +198,10 @@ class SumoCase:
 
         details = {
             "case_uuid": self._fmu_case_uuid,
-            "ensemble_uuid": self._ensemble_uuid,
-            "realization_uuid": self._realization_id,
+            "ensemble_uuid": get_field_from_metadata(
+                self.case_metadata, "fmu.ensemble.uuid"
+            ),
+            "realization_id": self._realization_id,
             "asset": get_field_from_metadata(
                 self.case_metadata, "access.asset.name"
             ),

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -198,6 +198,11 @@ class SumoCase:
 
         details = {
             "case_uuid": self._fmu_case_uuid,
+            "ensemble_uuid": self._ensemble_uuid,
+            "realization_uuid": self._realization_id,
+            "asset": get_field_from_metadata(
+                self.case_metadata, "access.asset.name"
+            ),
             "total_files_count": len(files_to_upload),
             "ok_files": len(ok_uploads),
             "failed_files": len(failed_uploads),

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -198,9 +198,7 @@ class SumoCase:
 
         details = {
             "case_uuid": self._fmu_case_uuid,
-            "ensemble_uuid": get_field_from_metadata(
-                self.case_metadata, "fmu.ensemble.uuid"
-            ),
+            "ert_ensemble_uuid": self._ensemble_uuid,
             "realization_id": self._realization_id,
             "asset": get_field_from_metadata(
                 self.case_metadata, "access.asset.name"

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -55,8 +55,6 @@ class SumoCase:
         self._files = []
         self.sumo_mode = sumo_mode
 
-        return
-
     def _load_export_manifest(self):
         """Load export manifest from file."""
 
@@ -219,8 +217,6 @@ class SumoCase:
         )
 
         return ok_uploads
-
-    pass
 
     def _update_sumo_uploads(self):
         """Update sumo uploads log."""

--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -45,7 +45,7 @@ class SumoCase:
             "_ERT_ENSEMBLE_ID", "default_ensemble"
         )
         self._realization_id = int(
-            os.environ.get("_ERT_REALIZATION_NUMBER", 0)
+            os.environ.get("_ERT_REALIZATION_NUMBER", "0")
         )
         logger.debug("self._fmu_case_uuid is %s", self._fmu_case_uuid)
         self._sumo_parent_id = self._fmu_case_uuid
@@ -192,7 +192,7 @@ class SumoCase:
         logger.info("Failed: %s", str(len(failed_uploads)))
         logger.info("Rejected: %s", str(len(rejected_uploads)))
         logger.info(f"Wall time: {_dt:.2f} sec")
-        logger.info(f"Sumo mode: {str(self.sumo_mode)}")
+        logger.info(f"Sumo mode: {self.sumo_mode}")
 
         details = {
             "case_uuid": self._fmu_case_uuid,

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -353,7 +353,6 @@ class SumoFile:
             )
             return result
 
-        self.sumo_parent_id = sumo_parent_id
         self.sumo_object_id = result["metadata_upload"].result.get("objectid")
 
         blob_url = result["metadata_upload"].result.get("blob_url")

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -265,7 +265,7 @@ async def upload_seismic_blob(object_id, path, metadata, blob_url):
 
     cmd_str = get_segyimport_cmd(blob_url, object_id, path, sample_unit)
     try:
-        cmd_result = subprocess.run(
+        cmd_result = subprocess.run(  # noqa: PLW1510 ASYNC221
             cmd_str, capture_output=True, text=True, shell=False
         )
         if cmd_result.returncode == 0:
@@ -273,8 +273,8 @@ async def upload_seismic_blob(object_id, path, metadata, blob_url):
         else:
             # Outer code expects and interprets http error codes
             logger.warning(
-                "Seismic upload failed with returncode",
-                cmd_result.returncode,
+                "Seismic upload failed with returncode "
+                + cmd_result.returncode,
             )
             raise Exception(
                 "FAILED SEGY upload as OpenVDS command " + cmd_result.stderr

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -387,7 +387,6 @@ class SumoFile:
 
             def update_retries(retry_state):
                 retries[0] = retry_state.attempt_number
-                return
 
             def return_last_value(retry_state):
                 return retry_state.outcome.result()

--- a/src/fmu/sumo/uploader/_sumofile.py
+++ b/src/fmu/sumo/uploader/_sumofile.py
@@ -154,7 +154,7 @@ async def upload_blob(blob_url, byte_string, retryer):
         await _upload_blob(blob_url, byte_string)
 
     await retryer(doit)
-    # response has the form {'etag': '"0x8DCDC8EED1510CC"', 'last_modified': datetime.datetime(2024, 9, 24, 11, 49, 20, tzinfo=datetime.timezone.utc), 'content_md5': bytearray(b'\x1bPM3(\xe1o\xdf(\x1d\x1f\xb9Qm\xd9\x0b'), 'client_request_id': '08c962a4-7a6b-11ef-8710-acde48001122', 'request_id': 'f459ad2b-801e-007d-1977-0ef6ee000000', 'version': '2024-11-04', 'version_id': None, 'date': datetime.datetime(2024, 9, 24, 11, 49, 19, tzinfo=datetime.timezone.utc), 'request_server_encrypted': True, 'encryption_key_sha256': None, 'encryption_scope': None}
+    # response has the form {'etag': '"0x8DCDC8EED1510CC"', 'last_modified': datetime.datetime(2024, 9, 24, 11, 49, 20, tzinfo=datetime.UTC), 'content_md5': bytearray(b'\x1bPM3(\xe1o\xdf(\x1d\x1f\xb9Qm\xd9\x0b'), 'client_request_id': '08c962a4-7a6b-11ef-8710-acde48001122', 'request_id': 'f459ad2b-801e-007d-1977-0ef6ee000000', 'version': '2024-11-04', 'version_id': None, 'date': datetime.datetime(2024, 9, 24, 11, 49, 19, tzinfo=datetime.UTC), 'request_server_encrypted': True, 'encryption_key_sha256': None, 'encryption_scope': None}
     # ... which is not what the caller expects, so we return something reasonable.
     return True
 

--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -160,11 +160,9 @@ async def _upload_files(
                 logger.warning(
                     f"Metadata upload status error exception: {error_string}"
                 )
-                pass
             except Exception as err:
                 err = err.with_traceback(None)
                 logger.warning(f"Metadata upload exception {err} {type(err)}")
-                pass
 
             paramfile = get_parameter_file(parameters_path, config_path)
             if paramfile is not None:

--- a/src/fmu/sumo/uploader/caseondisk.py
+++ b/src/fmu/sumo/uploader/caseondisk.py
@@ -168,9 +168,8 @@ class CaseOnDisk(SumoCase):
                 )
             except Exception as ex:
                 logger.warning(f"Unable to create shared access key: {ex}")
-                pass
 
-            logger.info("Case registered. SumoID: {}".format(sumo_parent_id))
+            logger.info(f"Case registered. SumoID: {sumo_parent_id}")
 
             return sumo_parent_id
         except Exception as err:

--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -178,7 +178,7 @@ def sumo_upload_main(
                     extra={"objectUuid": e.fmu_case_uuid},
                 )
             except Exception:
-                pass
+                logger.warning("Failed logging to exception to Sumo")
         return
 
 
@@ -292,7 +292,7 @@ def _check_arguments(args) -> None:
 
     if not Path(args.casepath).is_absolute():
         if args.casepath.startswith("<") and args.casepath.endswith(">"):
-            ValueError("ERT variable is not defined: %s", args.casepath)
+            raise ValueError("ERT variable is not defined: %s", args.casepath)
         raise ValueError(
             f"Provided casepath '{args.casepath}' must be an absolute path to the case root"
         )

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -718,8 +718,7 @@ def test_missing_child_metadata(
 
     warning_messages = [str(warning.message) for warning in warnings_record]
     assert any(
-        message.startswith("No metadata, skipping file")
-        or message.startswith("Invalid metadata")
+        message.startswith(("No metadata, skipping file", "Invalid metadata"))
         for message in warning_messages
     ), warning_messages
 
@@ -750,7 +749,7 @@ def test_invalid_yml_in_case_metadata(token):
     sumoclient = SumoClient(env=ENV, token=token)
 
     case_file = "tests/data/case_invalid.yml"
-    with pytest.warns(UserWarning) as warnings_record:
+    with pytest.warns(UserWarning) as warnings_record:  # noqa: PT031
         uploader.CaseOnDisk(
             case_metadata_path=case_file,
             casepath=CASEPATH,
@@ -841,7 +840,7 @@ def test_schema_error_in_case(token, case_metadata_path):
     with open(case_metadata_path, "w") as f:
         yaml.dump(parsed_yaml, f)
 
-    with pytest.warns(UserWarning, match="Registering case on Sumo failed*"):
+    with pytest.warns(UserWarning, match="Registering case on Sumo failed*"):  # noqa: PT031
         e = uploader.CaseOnDisk(
             case_metadata_path=case_metadata_path,
             casepath=CASEPATH,
@@ -1103,7 +1102,7 @@ def _get_segy_path(segy_command):
 def test_openvds_available():
     """Test that OpenVDS is installed and can be successfully called"""
     path_to_segy_import = _get_segy_path("SEGYImport")
-    check_segy_import_version = subprocess.run(
+    check_segy_import_version = subprocess.run(  # noqa: PLW1510
         [path_to_segy_import, "--version"], capture_output=True, text=True
     )
     assert check_segy_import_version.returncode == 0
@@ -1189,7 +1188,7 @@ def test_seismic_openvds_file(token, case_metadata_path, segy_file):
                 url_conn,
                 "exported.segy",
             ]
-            cmd_result = subprocess.run(
+            cmd_result = subprocess.run(  # noqa: PLW1510
                 cmdstr, capture_output=True, text=True, shell=False
             )
 

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -329,7 +329,7 @@ def test_case_dictionaries(explorer: Explorer):
     seed()
     random_index = randint(0, len(case.dictionaries) - 1)
     obj = case.dictionaries[random_index]
-    obj._blob
+    assert obj._blob
 
     print(f"{perfect_cases} 'perfect' cases out of {len(cases)}")
     # There could be many failed runs from komodo-release repo,

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -13,7 +13,7 @@ for those tests.
 import logging
 import os
 import sys
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from random import randint, seed
 

--- a/tests/test_uploads_from_komodo.py
+++ b/tests/test_uploads_from_komodo.py
@@ -13,7 +13,7 @@ for those tests.
 import logging
 import os
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from pathlib import Path
 from random import randint, seed
 
@@ -70,8 +70,8 @@ def _get_suitable_cases(explorer):
     cases = cases.filter(user="f_scout_ci")
     assert len(cases) > 0, "Found no cases uploaded by f_scout_ci"
     selected = []
-    an_hour_ago = datetime.now(timezone.utc) + timedelta(hours=-1)
-    a_day_ago = datetime.now(timezone.utc) + timedelta(hours=-24)
+    an_hour_ago = datetime.now(UTC) + timedelta(hours=-1)
+    a_day_ago = datetime.now(UTC) + timedelta(hours=-24)
     for case in cases:
         case_created = _get_creation_date(case.metadata)
         if case_created > an_hour_ago:


### PR DESCRIPTION
 ## Issue
related to https://github.com/equinor/sumo-canary/issues/382

## Description
- Remove unused variable `self._file_format`
- Remove unused variable `self.sumo_parent_object` (Update relevant places to use `self._sumo_parent_object` instead)
- Add `ert_ensemble_uuid`, `realization_uuid` and `asset` to upload details
- Switch from `datetime.timezone.utc` to `datetime.UTC` (apparently the latter is the newer way of doing it)
- A bit of Ruff check formatting things

## How to test
Run Drogon case, search Messagelog for upload summary and verify that the new fields are there.

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅