### PR TITLE
feat: set ensemble status to scratch when creating ensemble object

### DIFF
--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -147,13 +147,11 @@ async def _upload_files(
                     logger.warning(
                         f"Metadata upload status error exception: {error_string}"
                     )
-                    pass
                 except Exception as err:
                     err = err.with_traceback(None)
                     logger.warning(
                         f"Metadata upload exception {err} {type(err)}"
                     )
-                    pass
 
                 break
     all_results = []

--- a/src/fmu/sumo/uploader/_upload_files.py
+++ b/src/fmu/sumo/uploader/_upload_files.py
@@ -57,6 +57,7 @@ def maybe_upload_realization_and_ensemble(sumoclient, base_metadata):
             del ensemble_metadata["fmu"]["realization"]
             ensemble_metadata["class"] = "ensemble"
             ensemble_metadata["fmu"]["context"]["stage"] = "ensemble"
+            ensemble_metadata["_sumo"]["status"] = "scratch"
             sumoclient.post(f"/objects('{case_uuid}')", json=ensemble_metadata)
 
         sumoclient.post(f"/objects('{case_uuid}')", json=realization_metadata)
@@ -79,6 +80,7 @@ def maybe_upload_ensemble(sumoclient, base_metadata):
         ensemble_metadata = _base_object_metadata(base_metadata)
         ensemble_metadata["class"] = "ensemble"
         ensemble_metadata["fmu"]["context"]["stage"] = "ensemble"
+        ensemble_metadata["_sumo"]["status"] = "scratch"
 
         case_uuid = ensemble_metadata["fmu"]["case"]["uuid"]
         sumoclient.post(f"/objects('{case_uuid}')", json=ensemble_metadata)


### PR DESCRIPTION
 ## Issue
Close #258 

## Description
Set initial ensemble status to `scratch`

Tested in preview.
<img width="379" height="121" alt="Screenshot 2026-07-29 at 12 36 04" src="https://github.com/user-attachments/assets/c82c888b-40de-4f92-8273-74e4bb996b5d" />

## How to test

Run a Drogon case in preview with relevant changes in this branch, and verify initial ensemble status.

## Checklist
- [ ] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [ ] New/refactored code is following same conventions as the rest of the code base 🧬
- [ ] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [ ] Commits are semantic ✅