### PR TITLE
fix: leave fmu.sumo as a namespace package

### DIFF
--- a/src/fmu/sumo/uploader/_sumocase.py
+++ b/src/fmu/sumo/uploader/_sumocase.py
@@ -11,6 +11,7 @@ import time
 import warnings
 
 from fmu.dataio.manifest import get_manifest_path
+
 from fmu.sumo.uploader._logger import get_uploader_logger
 from fmu.sumo.uploader._upload_files import upload_files
 from fmu.sumo.uploader._utils import (


### PR DESCRIPTION
## How to test
Test with Komodo bleeding tomorrow, when this PR is in

## Checklist
- [ ] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [ ] New/refactored code is following same conventions as the rest of the code base 🧬
- [ ] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [ ] Commits are semantic ✅